### PR TITLE
add fan_speed plugin for newer model

### DIFF
--- a/System/fan_speed.5s.js
+++ b/System/fan_speed.5s.js
@@ -4,7 +4,7 @@
 // <bitbar.author>Masayuki Sunahara</bitbar.author>
 // <bitbar.author.github>tamanishi</bitbar.author.github>
 // <bitbar.desc>Shows fan speed. Strongly inpired by Eric Ripa's "Fan Speed" plugin.</bitbar.desc>
-// <bitbar.image>https://github.com/tamanishi/fan_speed/blob/master/image.png</bitbar.image>
+// <bitbar.image>https://github.com/tamanishi/fan_speed/blob/master/image.png?raw=true</bitbar.image>
 // <bitbar.dependencies>node</bitbar.dependencies>
 // <bitbar.abouturl>https://github.com/tamanishi/fan_speed</bitbar.abouturl> 
 

--- a/System/fan_speed.5s.js
+++ b/System/fan_speed.5s.js
@@ -1,12 +1,16 @@
 #!/usr/bin/env /usr/local/bin/node
-// <bitbar.title>fan_speed</bitbar.title>
-// <bitbar.version>v1.0</bitbar.version>
-// <bitbar.author>Masayuki Sunahara</bitbar.author>
-// <bitbar.author.github>tamanishi</bitbar.author.github>
-// <bitbar.desc>Shows fan speed. Strongly inpired by Eric Ripa's "Fan Speed" plugin.</bitbar.desc>
-// <bitbar.image>https://github.com/tamanishi/fan_speed/blob/master/image.png?raw=true</bitbar.image>
-// <bitbar.dependencies>node</bitbar.dependencies>
-// <bitbar.abouturl>https://github.com/tamanishi/fan_speed</bitbar.abouturl> 
+// <xbar.title>fan_speed</xbar.title>
+// <xbar.version>v1.0</xbar.version>
+// <xbar.author>Masayuki Sunahara</xbar.author>
+// <xbar.author.github>tamanishi</xbar.author.github>
+// <xbar.desc>Shows fan speed. Strongly inpired by Eric Ripa's "Fan Speed" plugin.</xbar.desc>
+// <xbar.image>https://github.com/tamanishi/fan_speed/blob/master/image.png?raw=true</xbar.image>
+// <xbar.dependencies>node,smc</xbar.dependencies>
+// <xbar.abouturl>https://github.com/tamanishi/fan_speed</xbar.abouturl>
+
+// To install smc:
+//   brew install --cask smcfancontrol
+//   ln -sf /Applications/smcFanControl.app/Contents/Resources/smc /usr/local/bin/smc
 
 const execSync = require('child_process').execSync
 

--- a/System/fan_speed.5s.js
+++ b/System/fan_speed.5s.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env /usr/local/bin/node
+// <bitbar.title>fan_speed</bitbar.title>
+// <bitbar.version>v1.0</bitbar.version>
+// <bitbar.author>Masayuki Sunahara</bitbar.author>
+// <bitbar.author.github>tamanishi</bitbar.author.github>
+// <bitbar.desc>Shows fan speed. Strongly inpired by Eric Ripa's "Fan Speed" plugin.</bitbar.desc>
+// <bitbar.image>https://github.com/tamanishi/fan_speed/blob/master/image.png</bitbar.image>
+// <bitbar.dependencies>node</bitbar.dependencies>
+// <bitbar.abouturl>https://github.com/tamanishi/fan_speed</bitbar.abouturl> 
+
+const execSync = require('child_process').execSync
+
+let speeds= '♨ '
+
+for (var fanCount = 0; fanCount < 2; fanCount++) {
+    // smc command responds like "  F0Ac  [flt ]  (bytes d0 f4 9c 44)".
+    let str = execSync(`/usr/local/bin/smc -k F${fanCount}Ac -r`).toString()
+    // extract inside parrens.
+    let result = str.match(/\(bytes (.+)\)/)
+    
+    let array = result[1].split(' ')
+    
+    let buffer = new ArrayBuffer(4)
+    let bytes = new Uint8Array(buffer)
+    
+    array.forEach((element, index) => {
+        bytes[index] = parseInt(element, 16)
+    })
+    
+    let view = new DataView(buffer)
+    
+    // "true" means "treat as Little-endian".
+    speeds += Math.floor(view.getFloat32(0, true)).toString()
+    speeds += ' rpm '
+}
+
+console.log(speeds + '| size=12')


### PR DESCRIPTION
There is already a plugin that shows fan speed, but it doesn't work on recent models.
This pull request adds a plugin for recent models.