### PR TITLE
Add a simple latency check 

### DIFF
--- a/Network/simple-latency.11s.sh
+++ b/Network/simple-latency.11s.sh
@@ -1,12 +1,11 @@
 #! /bin/zsh
-# <bitbar.title>Simple Latency</bitbar.title>
+# <bitbar.title>Simple-Latency</bitbar.title>
 # <bitbar.version>v1.0</bitbar.version>
 # <bitbar.author>Jerome</bitbar.author>
 # <bitbar.author.github>fine-fiddle</bitbar.author.github>
 # <bitbar.desc>Display a color categorized running average of your pingtime to an endpoint, plus any dropped packets.</bitbar.desc>
-# <bitbar.image>http://www.hosted-somewhere/pluginimage</bitbar.image>
+# <bitbar.image>https://imgur.com/oGuCKUd</bitbar.image>
 # <bitbar.dependencies>zsh</bitbar.dependencies>
-# <bitbar.abouturl>http://url-to-about.com/</bitbar.abouturl>
 
 
 GREEN='\033[1;32m';

--- a/Network/simple-latency.11s.sh
+++ b/Network/simple-latency.11s.sh
@@ -1,11 +1,11 @@
 #! /bin/zsh
-# <bitbar.title>Simple-Latency</bitbar.title>
-# <bitbar.version>v1.0</bitbar.version>
-# <bitbar.author>Jerome</bitbar.author>
-# <bitbar.author.github>fine-fiddle</bitbar.author.github>
-# <bitbar.desc>Display a color categorized running average of your pingtime to an endpoint, plus any dropped packets.</bitbar.desc>
-# <bitbar.image>https://imgur.com/oGuCKUd</bitbar.image>
-# <bitbar.dependencies>zsh</bitbar.dependencies>
+# <xbar.title>Simple-Latency</xbar.title>
+# <xbar.version>v1.0</xbar.version>
+# <xbar.author>Jerome</xbar.author>
+# <xbar.author.github>fine-fiddle</xbar.author.github>
+# <xbar.desc>Display a color categorized running average of your pingtime to an endpoint, plus any dropped packets.</xbar.desc>
+# <xbar.image>https://i.imgur.com/oGuCKUd.png</xbar.image>
+# <xbar.dependencies>zsh</xbar.dependencies>
 
 
 GREEN='\033[1;32m';

--- a/Network/simple-latency.11s.sh
+++ b/Network/simple-latency.11s.sh
@@ -1,0 +1,38 @@
+#! /bin/zsh
+# <bitbar.title>Simple Latency</bitbar.title>
+# <bitbar.version>v1.0</bitbar.version>
+# <bitbar.author>Jerome</bitbar.author>
+# <bitbar.author.github>fine-fiddle</bitbar.author.github>
+# <bitbar.desc>Display a color categorized running average of your pingtime to an endpoint, plus any dropped packets.</bitbar.desc>
+# <bitbar.image>http://www.hosted-somewhere/pluginimage</bitbar.image>
+# <bitbar.dependencies>zsh</bitbar.dependencies>
+# <bitbar.abouturl>http://url-to-about.com/</bitbar.abouturl>
+
+
+GREEN='\033[1;32m';
+YELLOW='\033[1;33m';
+BLUE='\033[1;34m';
+PURPLE='\033[1;35m';
+RED='\033[1;31m';
+NC='\033[0m';
+
+# NOTE- this must be less than the refresh time in the filename of this plugin. 
+PINGSPERITERATION=10;
+PINGDESTINATION=8.8.8.8;
+
+PINGOUT=$(ping -c ${PINGSPERITERATION} ${PINGDESTINATION} | tail -n 2);
+LATENCY=$(echo "${PINGOUT}" | tail -n 1 | sed 's/.*= //' | awk 'BEGIN { FS="/" } ; { print $2 }');
+DROPPED=$(echo "${PINGOUT}" | head -n 1 | awk '{ print $7 }');
+
+if [[ $LATENCY -lt 15 ]]; then PREFIX=$GREEN; fi;
+if [[ $LATENCY -ge 15 ]]; then PREFIX=$BLUE; fi;
+if [[ $LATENCY -ge 40 ]]; then PREFIX=$PURPLE; fi;
+if [[ $LATENCY -ge 70 ]]; then PREFIX=$RED; fi;
+
+if [[ $DROPPED != "0.0%" ]]; then 
+    PREFIX=$RED; 
+    echo "${PREFIX}$LATENCY•$DROPPED${NC}";
+    return 0;
+fi;
+
+echo "${PREFIX}$LATENCY${NC}";


### PR DESCRIPTION
Open to any feedback. 

This aims to be useful when: 
1) you're trying to document problems with the VPN in a big company. 
2) When you notice problems with a streaming application and wonder if you should start troubleshooting network issues or look at your provider's service page. 