### PR TITLE
add simple python based octoprint job percent

### DIFF
--- a/Tools/octoprint_job_percent.1m.py
+++ b/Tools/octoprint_job_percent.1m.py
@@ -11,10 +11,10 @@ import requests
 import re
 
 # edit to your octoprint ip address:port
-url = "http://192.168.1.39:5000/api/job"
+url = "http://octopi.local/api/job"
 
 # update to your api-key 
-headers = {"Accept": "application/json", "X-Api-Key": "FCDD9CAD9EEA41B2AADABD51B1CC93A3"}
+headers = {"Accept": "application/json", "X-Api-Key": "FCDD9CAD9XXXXXXXXXXXXXXXXXX"}
 
 result = requests.get(url,headers=headers)
 

--- a/Tools/octoprint_job_percent.1m.py
+++ b/Tools/octoprint_job_percent.1m.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+# <bitbar.title>Octoprint Job Percent</bitbar.title>
+# <bitbar.version>v1.0</bitbar.version>
+# <bitbar.author>Tavis Gustafson</bitbar.author>
+# <bitbar.author.github>tavdog</bitbar.author.github>
+# <bitbar.desc>Simple python octoprint job percent display</bitbar.desc>
+# <bitbar.dependencies>python</bitbar.dependencies>
+
+import requests
+import re
+
+# edit to your octoprint ip address:port
+url = "http://192.168.1.39:5000/api/job"
+
+# update to your api-key 
+headers = {"Accept": "application/json", "X-Api-Key": "FCDD9CAD9EEA41B2AADABD51B1CC93A3"}
+
+result = requests.get(url,headers=headers)
+
+try:
+    percent = re.search('"completion":(\d+)\.\d+', result.text).group(1)
+    print(percent + "%")
+except:
+    print("-")

--- a/Tools/octoprint_job_percent.1m.py
+++ b/Tools/octoprint_job_percent.1m.py
@@ -5,6 +5,7 @@
 # <bitbar.author.github>tavdog</bitbar.author.github>
 # <bitbar.desc>Simple python octoprint job percent display</bitbar.desc>
 # <bitbar.dependencies>python</bitbar.dependencies>
+# <bitbar.image>http://wildc.net/tmp/bitbar_octo_percent.png</bitbar.image>
 
 import requests
 import re


### PR DESCRIPTION
This is a very simple current job percent displayer for octoprint in python.  The existing octoprint plugin is harder to user and configure as a shell script. This python version is a minimal job percent display.