### PR TITLE
Updated to use current (v4) Linode api

### DIFF
--- a/Dev/Hosting/Linode/Linode.5m.php
+++ b/Dev/Hosting/Linode/Linode.5m.php
@@ -9,7 +9,7 @@
 // <bitbar.dependencies>linode-cli,php</bitbar.dependencies>
 
 $status = true;
-$json = shell_exec('/usr/local/bin/linode list -j');
+$json = shell_exec('/usr/local/bin/linode-cli linodes list --json');
 $servers = json_decode($json);
 $output = '---' . "\n";
 foreach($servers as $server)


### PR DESCRIPTION
I was getting an error on the foreach loop. Ended up being the binary being used. 

Updated line 12 to use linode-cli linodes list --json which lines up with Linode's v4 api. If you have linode-cli installed it should run as expected.