### PR TITLE
Fixes unquoted font name string causing 'malformed parameters: missing equals' error

### DIFF
--- a/Time/progress-procrastination.15s.sh
+++ b/Time/progress-procrastination.15s.sh
@@ -104,12 +104,12 @@ if [ "$now" -lt "$d_end" ] # tell me to stop if I'm past $working_end
 then
     if [ "$now" -lt "$d_start" ] # basically captures post-midnight oil-burning
     then
-        echo "😴SLEEP!🛌 | $bitbar size=12 font=SF Compact Text Regular"
+        echo "😴SLEEP!🛌 | $bitbar size=12 font='SF Compact Text Regular'"
     else
-        echo "P: $(round "$d_progress")% | $bitbar size=12 font=SF Compact Text Regular"
+        echo "P: $(round "$d_progress")% | $bitbar size=12 font='SF Compact Text Regular'"
     fi
 else
-    echo "🛑STOP!✋ | $bitbar size=12 font=SF Compact Text Regular"
+    echo "🛑STOP!✋ | $bitbar size=12 font='SF Compact Text Regular'"
 fi
 echo ---
 # day + progress bar


### PR DESCRIPTION
The PR adds quoting to a font name in Time/progress-procrastination.15s.sh that has spaces causing xbar to be unable to parse the output. Attached is the original error caused by this plugin: 

 
<img width="470" alt="progress-xbitbar-issue" src="https://user-images.githubusercontent.com/6668160/115119887-a3ec5b00-9f78-11eb-9f82-7e0b767bc878.png">
