### PR TITLE
update cardinals for Weather/DarkSky/weather.15m.py 

### DIFF
--- a/Weather/DarkSky/weather.15m.py
+++ b/Weather/DarkSky/weather.15m.py
@@ -89,9 +89,10 @@ def full_country_name(country):
   except urllib2.URLError:
     return False
 
-def calculate_bearing(degree):
-  cardinals = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW']
-  return cardinals[int(round(((6 * degree)) / 360))]
+def calculate_bearing(d):
+  dirs = ['N', 'NNE', 'NE', 'ENE', 'E', 'ESE', 'SE', 'SSE', 'S', 'SSW', 'SW', 'WSW', 'W', 'WNW', 'NW', 'NNW']
+  ix = int(round(d / (360. / len(dirs))))
+  return dirs[ix % len(dirs)]
 
 def get_wx_icon(icon_code):
   if icon_code == 'clear-day':


### PR DESCRIPTION
The original cardinals calculation left out degrees of accuracy but also did not seem to function correctly, for example, below test of the primary cardinal points do not return the expected results of N, E, S, W, N

```
def calculate_bearing(degree):
  cardinals = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW']
  return cardinals[int(round(((6 * degree)) / 360))]

# N, E, S, W, N
for i in (0,90,180,270,360):
   print(calculate_bearing(i))
```
returns 

```
N
NE
SE
S
W
```

The suggested change fixes this and includes finer granularity,[source](https://gist.github.com/RobertSudwarts/acf8df23a16afdb5837f)
