### PR TITLE
Fix diskAvailable plugin raising error window on BigSur

### DIFF
--- a/System/diskAvailable.sh
+++ b/System/diskAvailable.sh
@@ -11,6 +11,6 @@
 #df will report what is actually on the disk
 
 DEVICE=$(/bin/df -h |/usr/bin/awk '$9 ~ /^\/$/{print $1}')
-/usr/sbin/diskutil info "$DEVICE" |/usr/bin/awk '$0 ~ /Volume Free Space/ {print $4$5}'
+/usr/sbin/diskutil info "$DEVICE" |/usr/bin/awk '$0 ~ /(Container|Volume) Free Space/ {print $4$5}'
 
 #/bin/df -h / | awk '{print $4}' |grep -v 'Avail'


### PR DESCRIPTION
The plugin runs "diskutil info" command and for me the output of the command says "Container Free Space" and not "Volume Free Space" (as the plugin expects).
I am running BigSur 11.2.3 and the plugin was raising an error window saying "Application is not open anymore".

This small tweak fixes the problem and it looks to me that with this tweak the plugin should work on both diskutil outputs ("Container" and "Volume").
Sadly, I have no way to test this on an actual machine that outputs "Volume" and some feedback would be much appreciated.