### PR TITLE
Update pi-hole plugin

### DIFF
--- a/Network/pi-hole.10m.py
+++ b/Network/pi-hole.10m.py
@@ -120,11 +120,11 @@ def bitbar():
 
     print('Status: %s' % status)
     if enabled:
-        print('Disable Pi-hole | refresh=true href=%s' % url_disable)
-        print('Disable Pi-hole 30s | refresh=true href=%s' % url_disable_30s)
-        print('Disable Pi-hole 5m | refresh=true href=%s' % url_disable_5m)
+        print('Disable Pi-hole | refresh=true shell=curl param1=%s' % url_disable)
+        print('Disable Pi-hole 30s | refresh=true shell=curl param1=%s' % url_disable_30s)
+        print('Disable Pi-hole 5m | refresh=true shell=curl param1=%s' % url_disable_5m)
     else:
-        print('Enable Pi-hole | refresh=true href=%s' % url_enable)
+        print('Enable Pi-hole | refresh=true shell=curl param1=%s' % url_enable)
 
     separator()
     print("Domains being locked: %s" % summary['domains_being_blocked'])

--- a/Network/pi-hole.10m.py
+++ b/Network/pi-hole.10m.py
@@ -64,6 +64,8 @@ url_summary = "%s/api.php?summary" % base_url
 # Urls to enable/disable service
 url_enable = "%s/api.php?enable&auth=%s" % (base_url, password)
 url_disable = "%s/api.php?disable&auth=%s" % (base_url, password)
+url_disable_30s = "%s/api.php?disable=30&auth=%s" % (base_url, password)
+url_disable_5m = "%s/api.php?disable=300&auth=%s" % (base_url, password)
 
 
 # ---
@@ -74,8 +76,13 @@ def convert_to_native(data):
 
 
 def do_request(url, method='GET'):
-    response = urlopen(url)
-    return convert_to_native(response.read())
+    try:
+        response = urlopen(url)
+    except:
+        test = {'status': 'unavailable'}
+        return test
+    else:
+        return convert_to_native(response.read())
 
 
 def get_summary():
@@ -96,7 +103,7 @@ def separator():
 summary = get_summary()
 status = get_status()
 enabled = status == 'enabled'
-
+offline = status == 'unavailable'
 
 # Layout
 def bitbar():
@@ -104,12 +111,18 @@ def bitbar():
     print('| templateImage=%s' % globals()['icon_%s' % icon_type])
     separator()
 
+    if offline:
+        print("Pi-Hole unavailable")
+        return
+
     print("Open pi-hole admin | href=%s" % base_url)
     separator()
 
     print('Status: %s' % status)
     if enabled:
         print('Disable Pi-hole | refresh=true href=%s' % url_disable)
+        print('Disable Pi-hole 30s | refresh=true href=%s' % url_disable_30s)
+        print('Disable Pi-hole 5m | refresh=true href=%s' % url_disable_5m)
     else:
         print('Enable Pi-hole | refresh=true href=%s' % url_enable)
 


### PR DESCRIPTION
Add disable 30s and disable 5m options.
Clean up status message when your pi-hole is not reachable
Use curl instead of href tags so we don't have to open a web page in a browser