### PR TITLE
Remove unnecessary `/usr/sbin` and `/sbin` references

### DIFF
--- a/Dev/Kubernetes/minikube.5s.sh
+++ b/Dev/Kubernetes/minikube.5s.sh
@@ -13,6 +13,7 @@ MINIKUBE_LOGO_BW='iVBORw0KGgoAAAANSUhEUgAAAIAAAAB8CAYAAAChbripAAAABGdBTUEAALGPC/
 
 LANG="en_US.UTF-8"
 # You may need to update the PATH to include minikube and kubectl
+#PATH="/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 export LANG PATH
 
 if [[ $(minikube status | head -n 1) =~ Running ]]; then

--- a/Dev/Kubernetes/minikube.5s.sh
+++ b/Dev/Kubernetes/minikube.5s.sh
@@ -13,7 +13,6 @@ MINIKUBE_LOGO_BW='iVBORw0KGgoAAAANSUhEUgAAAIAAAAB8CAYAAAChbripAAAABGdBTUEAALGPC/
 
 LANG="en_US.UTF-8"
 # You may need to update the PATH to include minikube and kubectl
-#PATH="/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 export LANG PATH
 
 if [[ $(minikube status | head -n 1) =~ Running ]]; then

--- a/Network/openfortivpn.sh
+++ b/Network/openfortivpn.sh
@@ -23,7 +23,7 @@ VPN_EXECUTABLE=/usr/local/bin/openfortivpn
 VPN_EXECUTABLE_PARAMS="-c$HOME/Documents/.fortivpn-config" # Optional
 VPN_INTERFACE=ppp0
 # Command to determine if OpenFortiVPN is connected or disconnected
-VPN_CONNECTED="/sbin/ifconfig | egrep -A1 $VPN_INTERFACE | grep inet"
+VPN_CONNECTED="ifconfig | egrep -A1 $VPN_INTERFACE | grep inet"
 # Command to run to disconnect OpenFortiVPN
 VPN_DISCONNECT_CMD="sudo killall -2 openfortivpn"
 

--- a/Network/vpn_advanced.sh
+++ b/Network/vpn_advanced.sh
@@ -26,7 +26,7 @@ GET_VPN_PASSWORD="security find-generic-password -g -a joe.smith 2>&1 >/dev/null
 #GET_VPN_PASSWORD="cat ~/.vpnpass"
 #GET_VPN_PASSWORD="echo hunter2" # Not recommended
 # Command to determine if VPN is connected or disconnected
-VPN_CONNECTED="/sbin/ifconfig | egrep -A1 $VPN_INTERFACE | grep inet"
+VPN_CONNECTED="ifconfig | egrep -A1 $VPN_INTERFACE | grep inet"
 # Command to run to disconnect VPN
 VPN_DISCONNECT_CMD="sudo killall -2 openconnect"
 

--- a/System/Battery/watt-meter.20s.py
+++ b/System/Battery/watt-meter.20s.py
@@ -40,7 +40,7 @@ IMPACT = {
 }
 
 def parse_system_profiler():
-    output = subprocess.check_output(["/usr/sbin/system_profiler", \
+    output = subprocess.check_output(["system_profiler", \
                                      "-xml", "SPPowerDataType", "SPHardwareDataType"])
     plist = loads(output)
     spbattery_info = plist[0]['_items'][0]

--- a/System/HandoffToggle.1d.sh
+++ b/System/HandoffToggle.1d.sh
@@ -9,7 +9,7 @@
 # <xbar.dependencies>bash</xbar.dependencies>
 # <xbar.abouturl>https://github.com/martinschilliger/</xbar.abouturl>
 
-#UUID=$(/usr/sbin/system_profiler SPHardwareDataType | grep "Hardware UUID" | cut -c22-57)
+#UUID=$(system_profiler SPHardwareDataType | grep "Hardware UUID" | cut -c22-57)
 #PREF_FILE="${HOME}/Library/Preferences/ByHost/com.apple.coreservices.useractivityd.${UUID}.plist"
 PREF_FILE="${HOME}/Library/Preferences/ByHost/com.apple.coreservices.useractivityd.plist"
 
@@ -47,4 +47,3 @@ else
     echo "Activate Handoff| bash='$0' param1=enable terminal=false refresh=true emojize=false"
     exit
 fi
-

--- a/System/diskAvailable.sh
+++ b/System/diskAvailable.sh
@@ -11,6 +11,6 @@
 #df will report what is actually on the disk
 
 DEVICE=$(/bin/df -h |/usr/bin/awk '$9 ~ /^\/$/{print $1}')
-/usr/sbin/diskutil info "$DEVICE" |/usr/bin/awk '$0 ~ /(Container|Volume) Free Space/ {print $4$5}'
+diskutil info "$DEVICE" |/usr/bin/awk '$0 ~ /(Container|Volume) Free Space/ {print $4$5}'
 
 #/bin/df -h / | awk '{print $4}' |grep -v 'Avail'

--- a/System/power_wattage.30s.sh
+++ b/System/power_wattage.30s.sh
@@ -9,11 +9,11 @@
 # <xbar.dependencies></xbar.dependencies>
 # <xbar.abouturl></xbar.abouturl>
 
-power_wattage="$(/usr/sbin/system_profiler SPPowerDataType | grep "Wattage (W)" | awk "{print \$3\"W\"}")"
+power_wattage="$(system_profiler SPPowerDataType | grep "Wattage (W)" | awk "{print \$3\"W\"}")"
 
 if [ -z "$power_wattage" ]
 then
-  echo "🔋" 
+  echo "🔋"
 else
   echo "🔌${power_wattage}"
 fi

--- a/System/samplerate.sh
+++ b/System/samplerate.sh
@@ -12,7 +12,7 @@ IFS='
 
 device_index=0
 
-devices=($(/usr/sbin/system_profiler  \
+devices=($(system_profiler  \
   SPAudioDataType 2>/dev/null | \
   sed '1,/Devices/d' | \
   grep "^        \w" | \
@@ -26,7 +26,7 @@ elif [[ -f ~/.bitbar_audio_device_index ]]; then
 fi
 
 default_device="${devices[$device_index]}"
-samplerate=($(/usr/sbin/system_profiler  \
+samplerate=($(system_profiler  \
   SPAudioDataType 2>/dev/null | \
   sed '1,/'"${default_device}"'/d' | \
   grep SampleRate | \


### PR DESCRIPTION
See #1688

A [remaining reference](https://github.com/matryer/xbar-plugins/blob/b74b4799e6020df9e2d88c6ef536e852e167840c/Network/updatevpnbookpass.1d.sh#L73) is in `Network/updatevpnbookpass.1d.sh` as it also references a path `/Applications/Utilities/Keychain Access.app` which no longer existing on newer systems, so I guess that line is broken (hence commented).