### PR TITLE
Find all the tags instead of '[firsttag', as currently.

### DIFF
--- a/Time/watson.1m.sh
+++ b/Time/watson.1m.sh
@@ -33,7 +33,7 @@ started=$(echo "$status" | grep -E -o 'started (.*) \(')
 started="$(tr '[:lower:]' '[:upper:]' <<< "${started:0:1}")${started:1}"
 
 # get the tags
-tags=$(echo "$status" | awk '{printf "Tags: %s\n", $3}')
+tags=$(echo "$status" | awk -F "[][]" '{printf "Tags: %s\n", $2}')
 
 # main
 echo "$project"


### PR DESCRIPTION
The problem might have been caused by a change made to the output
of watson status command. In any case, this fix makes it compatible
with recent Watson versions.