### PR TITLE
Add github notification token variables

### DIFF
--- a/Dev/GitHub/notifications.30s.py
+++ b/Dev/GitHub/notifications.30s.py
@@ -8,6 +8,9 @@
 # <xbar.desc>GitHub (and GitHub:Enterprise) notifications in your menu bar!</xbar.desc>
 # <xbar.image>https://i.imgur.com/hW7dw9E.png</xbar.image>
 # <xbar.dependencies>python</xbar.dependencies>
+# <xbar.var>string(GITHUB_TOKEN): Github's token.</xbar.var>
+# <xbar.var>string(GITHUB_ENTERPRISE_TOKEN): Github's enterprise token.</xbar.var>
+# <xbar.var>string(GITHUB_ENTERPRISE_API="https://github.example.com/api/v3"): Github's enterprise api url.</xbar.var>
 
 import json
 import urllib2


### PR DESCRIPTION
<img width="722" alt="Screen Shot 2021-11-15 at 10 35 01" src="https://user-images.githubusercontent.com/1765216/141767343-0bcbe4d8-6975-4ffb-8fa7-3347edecaeea.png">

The image is self-explanatory, this adds new settings for the plugin.
