### PR TITLE
Add Ethereum and Polygon gas fee plugin

### DIFF
--- a/Cryptocurrency/Ethereum/eth_gas_widget.10m.rb
+++ b/Cryptocurrency/Ethereum/eth_gas_widget.10m.rb
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+
+# <bitbar.title>Ethereum Gas Fees</bitbar.title>
+# <bitbar.version>v1.0</bitbar.version>
+# <bitbar.author>Masumi Kawasaki</bitbar.author>
+# <bitbar.author.github>geeknees</bitbar.author.github>
+# <bitbar.desc>Widget for monitoring Ethereum Gas Fees from https://etherscan.io/</bitbar.desc>
+# <bitbar.dependencies>ruby</bitbar.dependencies>
+# <bitbar.image>https://raw.githubusercontent.com/geeknees/xbar-plugins/main/eth_gas_widget/screenshot.png</bitbar.image>
+# <bitbar.abouturl>https://github.com/geeknees/xbar-plugins</bitbar.abouturl>
+
+require 'open-uri'
+require 'json'
+
+ENDPOINT = "https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey="
+APIKEY = ""
+
+charset = nil
+html = URI.open(ENDPOINT+APIKEY) do |f|
+  charset = f.charset
+  f.read
+end
+
+response = JSON.parse(html)
+
+puts "⟠ #{response['result']['ProposeGasPrice']}"
+puts '---'
+
+response['result'].each do |k, v|
+  puts "#{k}: #{v.to_f.floor(5)}"
+end

--- a/Cryptocurrency/Polygon/polygon_gas_widget.10m.rb
+++ b/Cryptocurrency/Polygon/polygon_gas_widget.10m.rb
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+
+# <bitbar.title>Polygon Gas Fees</bitbar.title>
+# <bitbar.version>v1.0</bitbar.version>
+# <bitbar.author>Masumi Kawasaki</bitbar.author>
+# <bitbar.author.github>geeknees</bitbar.author.github>
+# <bitbar.desc>Widget for monitoring Polygon Gas Fees from https://polygonscan.com/</bitbar.desc>
+# <bitbar.dependencies>ruby</bitbar.dependencies>
+# <bitbar.image>https://raw.githubusercontent.com/geeknees/xbar-plugins/main/polygon_gas_widget/screenshot.png</bitbar.image>
+# <bitbar.abouturl>https://github.com/geeknees/xbar-plugins</bitbar.abouturl>
+
+require 'open-uri'
+require 'json'
+
+ENDPOINT = "https://api.polygonscan.com/api?module=gastracker&action=gasoracle&apikey="
+APIKEY = ""
+
+charset = nil
+html = URI.open(ENDPOINT+APIKEY) do |f|
+  charset = f.charset
+  f.read
+end
+
+response = JSON.parse(html)
+
+puts "♾️ #{response['result']['ProposeGasPrice']}"
+puts '---'
+
+response['result'].each do |k, v|
+  puts "#{k}: #{v.to_f.floor(5)}"
+end


### PR DESCRIPTION
This plugin displays the gas prices for Ethereum and Polygon. For Ethereum, it is equivalent to the existing plugin below, but this plugin seems to have stopped working due to a change in the site. Please check it out.

https://github.com/matryer/xbar-plugins/blob/main/Cryptocurrency/Ethereum/gasnow.10s.sh