### PR TITLE
add Battery management 🔋 plugin

### DIFF
--- a/Battery-management.m1.sh
+++ b/Battery-management.m1.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# <xbar.title>Battery management</xbar.title>
+# <xbar.version>1.0</xbar.version>
+# <xbar.author>Aland Mariwan</xbar.author>
+# <xbar.author.github>amariwan</xbar.author.github>
+# <xbar.desc>Get your battery cycles and as far as your macbook has reached 75% or 30% charge, you will be informed via your bot discord and condition on the menu bar !</xbar.desc>
+#
+
+# Get cycles number
+cycles=$(system_profiler SPPowerDataType | grep "Cycle Count" | awk '{print $3}')
+
+# Get battery condition
+condition=$(system_profiler SPPowerDataType | grep "Condition" | sed -e 's/^.*: //')
+
+# Get battery condition
+BatteryStatus=$(pmset -g batt | grep -Eo "\d+%" | cut -d% -f1)
+
+# If you want to change the emoticon before the number, here are some
+#echo "🔋 $cycles"
+#echo "♾ $cycles"
+#echo "♽ $cycles"
+
+echo "♽ $cycles"
+
+echo "---"
+
+# 1000 cycles maximum
+# Based on the cycles max number provided by Apple for all Macbooks after 2009
+# No way to get the Macbook age from script directly
+
+color=green
+if [ "$cycles" -gt 1000 ]; then
+    color=red
+elif [ "$cycles" -gt 750 ]; then
+    color=orange
+fi
+
+echo "Cycles: $cycles / 1000 | color=$color href='https://support.apple.com/en-us/HT201585'"
+
+
+
+color=green
+if [ "$condition" != "Normal" ]; then
+    color=red
+fi
+
+echo "Battery condition: $condition | color=$color"
+
+
+
+
+color=green
+if [ "$BatteryStatus" -ge "75" ]; then
+    color=red
+    osascript -e 'display notification "Battery Status '$BatteryStatus'" with title "Battery management"'
+    curl -v \
+-H "Authorization: Bot YOURTOKEN" \
+-H "User-Agent: myBotThing (http://some.url, v0.1)" \
+-H "Content-Type: application/json" \
+-X POST \
+-d '{"content":"'$BatteryStatus'"}' \
+https://discordapp.com/api/channels/CHANNELID/messages
+fi
+
+if [ "$BatteryStatus" –le "30" ]; then
+    color=red
+    osascript -e 'display notification "Battery Status '$BatteryStatus'" with title "Battery management"'
+    curl -v \
+-H "Authorization: Bot YOURTOKEN" \
+-H "User-Agent: myBotThing (http://some.url, v0.1)" \
+-H "Content-Type: application/json" \
+-X POST \
+-d '{"content":"'$BatteryStatus'"}' \
+https://discordapp.com/api/channels/CHANNELID/messages
+fi

--- a/Battery-management.m1.sh
+++ b/Battery-management.m1.sh
@@ -4,7 +4,7 @@
 # <xbar.author>Aland Mariwan</xbar.author>
 # <xbar.author.github>amariwan</xbar.author.github>
 # <xbar.desc>Get your battery cycles and as far as your macbook has reached 75% or 30% charge, you will be informed via your bot discord and condition on the menu bar !</xbar.desc>
-#
+# <xbar.image>https://github.com/amariwan/Macbook-Battery-management/blob/master/macbook.png?raw=true</xbar.image>
 
 # Get cycles number
 cycles=$(system_profiler SPPowerDataType | grep "Cycle Count" | awk '{print $3}')

--- a/Battery-management.m1.sh
+++ b/Battery-management.m1.sh
@@ -47,6 +47,7 @@ fi
 echo "Battery condition: $condition | color=$color"
 
 
+echo "Battery: $BatteryStatus | color=$color"
 
 
 color=green
@@ -54,22 +55,22 @@ if [ "$BatteryStatus" -ge "75" ]; then
     color=red
     osascript -e 'display notification "Battery Status '$BatteryStatus'" with title "Battery management"'
     curl -v \
--H "Authorization: Bot YOURTOKEN" \
+-H "Authorization: Bot ODc1Nzg4OTc1MTgzMzg4NzUz.YRaoCw.eGS37xSrmk5mInOpo2pBmYeb6rw" \
 -H "User-Agent: myBotThing (http://some.url, v0.1)" \
 -H "Content-Type: application/json" \
 -X POST \
 -d '{"content":"'$BatteryStatus'"}' \
-https://discordapp.com/api/channels/CHANNELID/messages
+https://discordapp.com/api/channels/948694642394808320/messages
 fi
 
 if [ "$BatteryStatus" –le "30" ]; then
     color=red
     osascript -e 'display notification "Battery Status '$BatteryStatus'" with title "Battery management"'
     curl -v \
--H "Authorization: Bot YOURTOKEN" \
+-H "Authorization: Bot ODc1Nzg4OTc1MTgzMzg4NzUz.YRaoCw.eGS37xSrmk5mInOpo2pBmYeb6rw" \
 -H "User-Agent: myBotThing (http://some.url, v0.1)" \
 -H "Content-Type: application/json" \
 -X POST \
 -d '{"content":"'$BatteryStatus'"}' \
-https://discordapp.com/api/channels/CHANNELID/messages
+https://discordapp.com/api/channels/948694642394808320/messages
 fi

--- a/Battery-management.m1.sh
+++ b/Battery-management.m1.sh
@@ -37,8 +37,6 @@ fi
 
 echo "Cycles: $cycles / 1000 | color=$color href='https://support.apple.com/en-us/HT201585'"
 
-
-
 color=green
 if [ "$condition" != "Normal" ]; then
     color=red
@@ -47,8 +45,8 @@ fi
 echo "Battery condition: $condition | color=$color"
 
 
-echo "Battery: $BatteryStatus | color=$color"
 
+echo "Battery: $BatteryStatus | color=$color"
 
 color=green
 if [ "$BatteryStatus" -ge "75" ]; then


### PR DESCRIPTION
# Battery management. 

Get your battery cycles and as far as your macbook has reached 75% or 30% charge, you will be informed via your bot discord and condition on the menu bar !


![macbook Screenshot](https://github.com/amariwan/Macbook-Battery-management/blob/master/macbook.png?raw=true)