### PR TITLE
showhide-files plugin: add python3 compatibility

### DIFF
--- a/System/showhide-files.1d.py
+++ b/System/showhide-files.1d.py
@@ -1,31 +1,36 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 #
-# <xbar.title>Show hidden files in Finder</xbar.title>
-# <xbar.version>v0.2</xbar.version>
-# <xbar.author>Thomas Kurz</xbar.author>
+# <xbar.title>Show/hide hidden files and desktop icons</xbar.title>
+# <xbar.version>v0.3</xbar.version>
+# <xbar.author>Thomas Kurz, Robin Moser</xbar.author>
 # <xbar.author.github>dashorty</xbar.author.github>
 # <xbar.desc>Show hidden files in Finder</xbar.desc>
-# <xbar.image>https://github.com/dashorty/bitbar-showhide-files/blob/master/screenshot.png?raw=true</xbar.image>
+# <xbar.image>https://i.imgur.com/h2Mdxye.png</xbar.image>
 # <xbar.abouturl>https://github.com/dashorty/bitbar-showhide-files</xbar.abouturl>
 
 import sys
 import os
 
 if len(sys.argv) == 1:
-    print "| templateImage=iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAQAAABKfvVzAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QAAKqNIzIAAAAJcEhZcwAADdcAAA3XAUIom3gAAAAHdElNRQfiAwIWGC2lnrmcAAAA8UlEQVQ4y92SMW7CUBBEX9JZQikxDVS0VKShceEbcBkkDhHREwquQIm4ABUHQOIAlKZCisJLE+z/bUeK6JLp/uxo/87uwL+FXbu/E45derBQtfDg0vHP4ql777hZYe+0Ke64LgUbcxNTM3clt7YTykcey9IsajQv+aOjOzn0XHUHsO+bKycAwS9nh4A9T8G8OTjwquqnEzALqid7uA2Imwm4KN8rMDXE9jny/sQLUNkrgAvG+4lHysBXP1S92gfz2kg107vv8727cADgpma6sdZ59P+sZa2Nw+3MTE3Mg+7x4VqiEYajLRoPhe+heP9JfAEpl32XjyFcEgAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOC0wMy0wMlQyMjoyNDo0NSswMTowMFm39GAAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTgtMDMtMDJUMjI6MjQ6NDUrMDE6MDAo6kzcAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAABJRU5ErkJggg=="
-    print '---'
-    print 'show hidden files | terminal=false bash=%s param1=show' % sys.argv[0]
-    print 'hide hidden files | terminal=false bash=%s param1=hide' % sys.argv[0]
-    print '---'
-    print 'show desktop icons | terminal=false bash=%s param1=showicn' % sys.argv[0]
-    print 'hide desktop icons | terminal=false bash=%s param1=hideicn' % sys.argv[0]
-elif sys.argv[1] == 'show':
-    os.system('defaults write com.apple.finder AppleShowAllFiles YES && killall Finder')
-elif sys.argv[1] == 'hide':
-    os.system('defaults write com.apple.finder AppleShowAllFiles NO && killall Finder')
-elif sys.argv[1] == 'showicn':
-    os.system('defaults write com.apple.finder CreateDesktop YES && killall Finder')
-elif sys.argv[1] == 'hideicn':
-    os.system('defaults write com.apple.finder CreateDesktop NO && killall Finder')
 
+    print("| templateImage=iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAQAAABKfvVzAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QAAKqNIzIAAAAJcEhZcwAADdcAAA3XAUIom3gAAAAHdElNRQfiAwIWGC2lnrmcAAAA8UlEQVQ4y92SMW7CUBBEX9JZQikxDVS0VKShceEbcBkkDhHREwquQIm4ABUHQOIAlKZCisJLE+z/bUeK6JLp/uxo/87uwL+FXbu/E45derBQtfDg0vHP4ql777hZYe+0Ke64LgUbcxNTM3clt7YTykcey9IsajQv+aOjOzn0XHUHsO+bKycAwS9nh4A9T8G8OTjwquqnEzALqid7uA2Imwm4KN8rMDXE9jny/sQLUNkrgAvG+4lHysBXP1S92gfz2kg107vv8727cADgpma6sdZ59P+sZa2Nw+3MTE3Mg+7x4VqiEYajLRoPhe+heP9JfAEpl32XjyFcEgAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOC0wMy0wMlQyMjoyNDo0NSswMTowMFm39GAAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTgtMDMtMDJUMjI6MjQ6NDUrMDE6MDAo6kzcAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAABJRU5ErkJggg==")
+
+    print('---')
+    print('show hidden files | terminal=false bash={} param1=showHidden'.format(sys.argv[0]))
+    print('hide hidden files | terminal=false bash={} param1=hideHidden'.format(sys.argv[0]))
+
+    print('---')
+    print('show desktop icons | terminal=false bash={} param1=showIcons'.format(sys.argv[0]))
+    print('hide desktop icons | terminal=false bash={} param1=hideIcons'.format(sys.argv[0]))
+
+elif sys.argv[1] == 'showHidden':
+    os.system('defaults write com.apple.finder AppleShowAllFiles YES && killall Finder')
+
+elif sys.argv[1] == 'hideHidden':
+    os.system('defaults write com.apple.finder AppleShowAllFiles NO && killall Finder')
+
+elif sys.argv[1] == 'showIcons':
+    os.system('defaults write com.apple.finder CreateDesktop YES && killall Finder')
+
+elif sys.argv[1] == 'hideIcons':
+    os.system('defaults write com.apple.finder CreateDesktop NO && killall Finder')


### PR DESCRIPTION
Since the new MacOS version, python2 isn't shipped anymore, the plugin had to made compatible with python3. The screenshot was replaced to match new options.