### PR TITLE
real-cpu-usage-chart spark fix for M1 mac homebrew

### DIFF
--- a/System/real-cpu-usage-chart.10s.sh
+++ b/System/real-cpu-usage-chart.10s.sh
@@ -12,9 +12,15 @@
 #
 # This script requires https://github.com/holman/spark
 
-SPARK="/usr/local/bin/spark"
+SPARK_INTEL="/usr/local/bin/spark"
+SPARK_ARM="/opt/homebrew/bin/spark"
+SPARK=
 
-if [ ! -f "${SPARK}" ]; then
+if [ -f "${SPARK_INTEL}" ]; then
+    SPARK="${SPARK_INTEL}"
+elif [ -f "${SPARK_ARM}" ]; then
+    SPARK="${SPARK_ARM}"
+else
     echo "Install spark utility please."
     exit 1
 fi


### PR DESCRIPTION
Homebrew installations on M1 Macs go into `/opt/homebrew` by default now as to avoid mixing with intel-based software under `/usr/local`.  This allows the real-cpu-usage-chart to quickly confirm if the spark dependency should be pulled from a different homebrew path.