### PR TITLE
Make terminal not show and refresh bar

### DIFF
--- a/Network/dnsswitcher.1d.sh
+++ b/Network/dnsswitcher.1d.sh
@@ -101,5 +101,5 @@ dns_address='$(eval "echo \${${dns_name[*]}}")'
 networksetup -setdnsservers $network_service \$(echo \$dns_address)
 EOF
   chmod 700 "$switcher"
-  echo "$dns_name | bash=$switcher | terminal=false | refresh=true"
+  echo "$dns_name | terminal=false refresh=true bash=$switcher"
 done


### PR DESCRIPTION
Rearranging order acts as intended:
- Terminal will NOT show when a new DNS profile selected
- Bar WILL refresh when a new DNS profile is selected