### PR TITLE
fix(GitLab Merge Requests Plugin): pin the globally installed bitbar module to major version 1

### DIFF
--- a/Dev/Gitlab/gitlab_merge_requests.js
+++ b/Dev/Gitlab/gitlab_merge_requests.js
@@ -528,7 +528,7 @@ function installBitbarModule() {
   const npm = npmBin();
 
   // The install command
-  const cmd = npm + " install -g bitbar";
+  const cmd = npm + " install -g bitbar@1";
 
   console.log("Installing the BitBar Node module...");
 


### PR DESCRIPTION
Version 2 of the bitbar module has a breaking change: https://github.com/sindresorhus/xbar/releases/tag/v2.0.0