### PR TITLE
Use consistent Python 3 shebang

### DIFF
--- a/AWS/cloudwatch-alarms.30s.py
+++ b/AWS/cloudwatch-alarms.30s.py
@@ -1,5 +1,4 @@
-#!/usr/local/bin/python3
-# -*- coding: UTF-8 -*-
+#!/usr/bin/env python3
 
 # <xbar.title>CloudWatch Alarms Status</xbar.title>
 # <xbar.version>v1.0</xbar.version>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,7 +224,7 @@ Anything that can write to standard out is supported, but here is a list that ha
 1. Python3
    - Status: Working
    - Output: `print("your string here")`
-   - Caveats: To output unicode shebang has to be in the format `#!/usr/bin/env PYTHONIOENCODING=UTF-8 /path/to/the/python3`
+   - Caveats: To output unicode shebang has to be in the format `#!/usr/bin/env python3`
 1. JavaScript (`node`)
    - Status: Working
    - Caveats: Shebang has to be in the format `#!/usr/bin/env /path/to/the/node/executable`

--- a/Cryptocurrency/Bitcoin/tr-markets.1m.py
+++ b/Cryptocurrency/Bitcoin/tr-markets.1m.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env PYTHONIOENCODING=UTF-8 /usr/local/bin/python3
+#!/usr/bin/env python3
+
 # <xbar.title>BTC Ticker for TR Markets</xbar.title>
 # <xbar.version>v1.0</xbar.version>
 # <xbar.author>Erhan BÜTE</xbar.author>

--- a/Cryptocurrency/Ethereum/eth_wallet_balances.1m.py
+++ b/Cryptocurrency/Ethereum/eth_wallet_balances.1m.py
@@ -1,4 +1,5 @@
-#!/usr/local/homebrew/bin/python3
+#!/usr/bin/env python3
+
 """Loads Ethereum wallet address (configured below) and all tokens associated with
    each address. Then displays current $USD value in the bitbar title, with a drop-down
    showing each total value for owned ETH and each token.

--- a/Cryptocurrency/Ethereum/ethminer.5s.py
+++ b/Cryptocurrency/Ethereum/ethminer.5s.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 
 # <xbar.title>EthMiner</xbar.title>
 # <xbar.version>v1.0</xbar.version>

--- a/Cryptocurrency/cardano.10s.py
+++ b/Cryptocurrency/cardano.10s.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env /usr/local/bin/python3
-# coding=utf-8
+#!/usr/bin/env python3
 
 """
 # <xbar.title>Cardano (ADA) Price Monitor</xbar.title>

--- a/Cryptocurrency/coincap.1m.py
+++ b/Cryptocurrency/coincap.1m.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env PYTHONIOENCODING=UTF-8 /usr/local/bin/python3
+#!/usr/bin/env python3
 
 # <xbar.title>CoinCap</xbar.title>
 # <xbar.version>v1.0</xbar.version>

--- a/Cryptocurrency/coincaplite.1m.py
+++ b/Cryptocurrency/coincaplite.1m.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env PYTHONIOENCODING=UTF-8 /usr/local/bin/python3
+#!/usr/bin/env python3
 
 import requests
 

--- a/Dev/Gitlab/gitlab_glance.15m.py
+++ b/Dev/Gitlab/gitlab_glance.15m.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env PYTHONIOENCODING=UTF-8 /usr/bin/python3
+#!/usr/bin/env python3
 
 # <xbar.title>GitLab Glance</xbar.title>
 # <xbar.version>v2.0</xbar.version>

--- a/Dev/Jira/jira-issues.10m.py
+++ b/Dev/Jira/jira-issues.10m.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 
 # <xbar.title>Jira issues</xbar.title>
 # <xbar.version>v1.0</xbar.version>

--- a/Dev/Nagios/thruk.py
+++ b/Dev/Nagios/thruk.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env PYTHONIOENCODING=utf8 PYTHONUNBUFFERED=1 /usr/local/bin/python3
+#!/usr/bin/env python3
 
 # <xbar.title>Thruk</xbar.title>
 # <xbar.author>Brian Hartvigsen</xbar.author>

--- a/Dev/noti.1m.py
+++ b/Dev/noti.1m.py
@@ -1,6 +1,5 @@
-#!/usr/local/bin/python3
-# -*- coding: utf-8 -*-
-#
+#!/usr/bin/env python3
+
 # <xbar.title>Noti</xbar.title>
 # <xbar.version>v0.5</xbar.version>
 # <xbar.author>ye11ow</xbar.author>

--- a/E-Commerce/nvidia.3m.py
+++ b/E-Commerce/nvidia.3m.py
@@ -1,4 +1,4 @@
-#!/Library/Frameworks/Python.framework/Versions/3.6/bin/python3
+#!/usr/bin/env python3
 
 # <xbar.title>1080ti Stock Checker</xbar.title>
 # <xbar.version>v2.0</xbar.version>

--- a/Environment/CO2-Signal.10m.py
+++ b/Environment/CO2-Signal.10m.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env PYTHONIOENCODING=UTF-8 /usr/local/bin/python3
+#!/usr/bin/env python3
 
 # <xbar.title>CO2Signal API</xbar.title>
 # <xbar.version>v1.0</xbar.version>

--- a/Finance/hours.1m.py
+++ b/Finance/hours.1m.py
@@ -1,4 +1,5 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
+
 # <xbar.title>hours</xbar.title>
 # <xbar.version>v2.0</xbar.version>
 # <xbar.author>Udey Rishi</xbar.author>

--- a/Finance/robinhood2.1m.py
+++ b/Finance/robinhood2.1m.py
@@ -1,5 +1,4 @@
-#!/usr/local/bin/python3
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
 # <xbar.title>Robinhood2</xbar.title>
 # <xbar.version>v1.0</xbar.version>

--- a/Finance/yahoo_stock_ticker.10m.py
+++ b/Finance/yahoo_stock_ticker.10m.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env LC_ALL=en_US.UTF-8 /usr/local/bin/python3
-#
+#!/usr/bin/env python3
+
 # <xbar.title>Yahoo Stock Ticker</xbar.title>
 # <xbar.version>v1.1</xbar.version>
 # <xbar.author>Long Do</xbar.author>

--- a/IoT/BMWcharge.15m.py
+++ b/IoT/BMWcharge.15m.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env PYTHONIOENCODING=UTF-8 python3
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
 # <xbar.title>BMW Charging Status</xbar.title>
 # <xbar.version>v1.0</xbar.version>

--- a/Lifestyle/zoom_onair.15s.py
+++ b/Lifestyle/zoom_onair.15s.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env PYTHONIOENCODING=UTF-8 python3
+#!/usr/bin/env python3
 
 #  <xbar.title>Zoom On-Air</xbar.title>
 #  <xbar.version>v0.1</xbar.version>

--- a/Music/ksing.1d.py
+++ b/Music/ksing.1d.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env PYTHONIOENCODING=UTF-8 python3
+#!/usr/bin/env python3
 
 # xbar Metadata
 # <xbar.title>KSing 全民K歌</xbar.title>

--- a/Science/apod.1h.py
+++ b/Science/apod.1h.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env PYTHONIOENCODING=UTF-8 /usr/local/bin/python3
+#!/usr/bin/env python3
 
 # Copyright 2019 Jacob Vossen 
 

--- a/Sports/bundesliga.1h.py
+++ b/Sports/bundesliga.1h.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env PYTHONIOENCODING=UTF-8 /usr/local/bin/python3
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
+
 # <xbar.title>Bundesliga Matchday</xbar.title>
 # <xbar.version>v1.0</xbar.version>
 # <xbar.author>Alex</xbar.author>

--- a/Sports/fcbarcelona-dk.1h.py
+++ b/Sports/fcbarcelona-dk.1h.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env PYTHONIOENCODING=UTF-8 /usr/local/bin/python3
+#!/usr/bin/env python3
 
 # <xbar.title>FCBarcelona.dk</xbar.title>
 # <xbar.version>v1.0</xbar.version>

--- a/Sports/live_nba.1m.py
+++ b/Sports/live_nba.1m.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env PYTHONIOENCODING=UTF-8 /usr/local/bin/python3
+#!/usr/bin/env python3
 
 # <xbar.title>Live NBA Game Stat</xbar.title>
 # <xbar.version>v1.0</xbar.version>

--- a/System/DoNotDisturb.1s.py
+++ b/System/DoNotDisturb.1s.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env LC_ALL=en_US.UTF-8 /usr/local/bin/python3
+#!/usr/bin/env python3
+
 # <xbar.title>Do Not Disturb</xbar.title>
 # <xbar.author>Weibing Chen</xbar.author>
 # <xbar.author.github>weibingchen17</xbar.author.github>

--- a/Weather/weather.15m.py
+++ b/Weather/weather.15m.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env PYTHONIOENCODING=UTF-8 /usr/bin/python3
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
 # <xbar.title>Weather - OpenWeatherMap</xbar.title>
 # <xbar.version>v1.3</xbar.version>

--- a/Weather/yahoo-weather.5m.py
+++ b/Weather/yahoo-weather.5m.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env LC_ALL=en_US.UTF-8 /usr/local/bin/python3
-#
+#!/usr/bin/env python3
+
 # <xbar.title>Yahoo Weather</xbar.title>
 # <xbar.version>v3.0</xbar.version>
 # <xbar.author>mgjo5899</xbar.author>

--- a/Web/ProductHunt/producthunt-tech-hunts.1d.py
+++ b/Web/ProductHunt/producthunt-tech-hunts.1d.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env PYTHONIOENCODING=UTF-8 /usr/bin/python3
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
 # <xbar.title>Product Hunt - Today in Tech</xbar.title>
 # <xbar.version>v1.1.0</xbar.version>

--- a/Web/bilibili.py
+++ b/Web/bilibili.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env PYTHONIOENCODING=UTF-8 /usr/local/bin/python3
-# coding=utf-8
-#
+#!/usr/bin/env python3
+
 # <xbar.title>B站UP主粉丝和投稿视频播放信息获取</xbar.title>
 # <xbar.version>v1.0</xbar.version>
 # <xbar.author>胖哥带你入坑带你飞</xbar.author>

--- a/Web/bitbar-uptime_robot.py
+++ b/Web/bitbar-uptime_robot.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 
 # <xbar.title>UptimeRobot Monitor</xbar.title>
 # <xbar.version>v0.1</xbar.version>

--- a/Web/putio.5m.py
+++ b/Web/putio.5m.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 
 # <xbar.title>put.io transfers</xbar.title>
 # <xbar.version>v1.0</xbar.version>

--- a/Web/todays_tweets.30m.py
+++ b/Web/todays_tweets.30m.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env PYTHONIOENCODING=UTF-8 /usr/local/bin/python3
+#!/usr/bin/env python3
 
 # <xbar.title>Today's Tweets</xbar.title>
 # <xbar.version>v1.2.1</xbar.version>

--- a/Web/wanikani.15m.py
+++ b/Web/wanikani.15m.py
@@ -1,5 +1,4 @@
-#!/usr/local/bin/python3.6
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
 # BitBar plugin that displays the number of items and some basic information from WaniKani!
 


### PR DESCRIPTION
This pull request uses a consistent Python 3 shebang, Python 3 uses UTF-8 by default as well. Some plug-ins used `/usr/local/bin/python3` which would fail for many users.