### PR TITLE
Update transferwise-currency-tracker to python3

### DIFF
--- a/Finance/transferwise-currency-tracker.1m.py
+++ b/Finance/transferwise-currency-tracker.1m.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # <xbar.title>Currency Tracker Transferwise</xbar.title>
 # <xbar.version>1.0</xbar.version>
@@ -8,8 +8,8 @@
 # <xbar.dependencies>python</xbar.dependencies>
 # <xbar.image>http://andrewzk.github.io/gh-pages/transferwise.png</xbar.image>
 
-import urllib2
 import json
+from urllib.request import urlopen, Request
 
 TRANSFERWISE_KEY = "dad99d7d8e52c2c8aaf9fda788d8acdc"
 
@@ -22,11 +22,11 @@ url = "https://transferwise.com/api/v1/payment/calculate?amount=1" \
       "&isGuaranteedFixedTarget=false" \
       "&sourceCurrency={}&targetCurrency={}".format(currency_from, currency_to)
 
-req = urllib2.Request(url)
+req = Request(url)
 req.add_header('X-Authorization-key', TRANSFERWISE_KEY)
 
-result = json.loads(urllib2.urlopen(req).read())['transferwiseRate']
+result = json.loads(urlopen(req).read())['transferwiseRate']
 
-print "{}: {:.2f}".format(currency_to, result)
-print "---"
-print "From: {}".format(currency_from)
+print ("{}: {:.2f}".format(currency_to, result))
+print ("---")
+print ("From: {}".format(currency_from))


### PR DESCRIPTION
fix: using python3 because macOS 12.3 removed python2