### PR TITLE
feat(Dev/Homebrew/brew-updates): new options and style changes

### DIFF
--- a/Dev/Homebrew/brew-updates.1h.rb
+++ b/Dev/Homebrew/brew-updates.1h.rb
@@ -1,17 +1,25 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# rubocop:disable Layout/LineLength
+
 # <xbar.title>Brew Updates</xbar.title>
-# <xbar.version>v2.4.0</xbar.version>
+# <xbar.version>v2.6.1</xbar.version>
 # <xbar.author>Jim Myhrberg</xbar.author>
 # <xbar.author.github>jimeh</xbar.author.github>
 # <xbar.desc>List and manage outdated Homebrew formulas and casks</xbar.desc>
-# <xbar.image>https://i.imgur.com/HLKYqYc.png</xbar.image>
+# <xbar.image>https://i.imgur.com/HbSHhaa.png</xbar.image>
 # <xbar.dependencies>ruby</xbar.dependencies>
 # <xbar.abouturl>https://github.com/jimeh/dotfiles/tree/main/xbar</xbar.abouturl>
 #
 # <xbar.var>string(VAR_BREW_PATH=""): Path to "brew" executable.</xbar.var>
-# <xbar.var>boolean(VAR_GREEDY=false): Pass --greedy to brew outdated command</xbar.var>
+# <xbar.var>boolean(VAR_GREEDY_LATEST=false): Run "brew outdated" with --greedy-latest flag..</xbar.var>
+# <xbar.var>boolean(VAR_GREEDY_AUTO_UPDATES=false): Run "brew outdated" with --greedy-auto-updates flag.</xbar.var>
+# <xbar.var>boolean(VAR_POST_RUN_CLEANUP=false): Run "brew cleanup" after package changes.</xbar.var>
+# <xbar.var>boolean(VAR_POST_RUN_DOCTOR=false): Run "brew cleanup" after package changes.</xbar.var>
+# <xbar.var>string(VAR_UPGRADE_ALL_EXCLUDE=""): Comma-separated list formulas/casks to exclude from upgrade all operations.</xbar.var>
+
+# rubocop:enable Layout/LineLength
 
 # rubocop:disable Lint/ShadowingOuterLocalVariable
 # rubocop:disable Metrics/AbcSize
@@ -24,8 +32,36 @@
 
 require 'open3'
 require 'json'
+require 'set'
 
 module Xbar
+  class CommandError < StandardError; end
+  class RPCError < StandardError; end
+
+  module Service
+    private
+
+    def config
+      @config ||= Xbar::Config.new
+    end
+
+    def printer
+      @printer ||= ::Xbar::Printer.new
+    end
+
+    def cmd(*args)
+      out, err, s = Open3.capture3(*args)
+      if s.exitstatus != 0
+        msg = "Command failed: #{args.join(' ')}"
+        msg += ": #{err}" unless err.empty?
+
+        raise CommandError, msg
+      end
+
+      out
+    end
+  end
+
   class Runner
     attr_reader :service
 
@@ -35,7 +71,9 @@ module Xbar
 
     def run(argv = [])
       return service.run if argv.empty?
-      return unless service.respond_to?(argv[0])
+      unless service.respond_to?(argv[0])
+        raise RPCError, "Unknown RPC method: #{argv[0]}"
+      end
 
       service.public_send(*argv)
     end
@@ -48,6 +86,12 @@ module Xbar
       return unless File.exist?(filename)
 
       merge!(JSON.parse(File.read(filename)))
+    end
+
+    def as_set(name)
+      values = self[name]&.to_s&.split(',')&.map(&:strip)&.reject(&:empty?)
+
+      ::Set.new(values || [])
     end
 
     def filename
@@ -144,9 +188,9 @@ module Xbar
 end
 
 module Brew
-  class CommandError < StandardError; end
-
   class Common
+    include Xbar::Service
+
     def self.prefix(value = nil)
       return @prefix if value.nil? || value == ''
 
@@ -159,17 +203,6 @@ module Brew
       self.class.prefix
     end
 
-    def default_printer
-      @default_printer ||= ::Xbar::Printer.new
-    end
-
-    def cmd(*args)
-      out, err, s = Open3.capture3(*args)
-      raise CommandError, "#{args.join(' ')}: #{err}" if s.exitstatus != 0
-
-      out
-    end
-
     def brew_path
       @brew_path ||= brew_path_from_env ||
                      brew_path_from_which ||
@@ -178,9 +211,12 @@ module Brew
     end
 
     def brew_path_from_env
-      return if ENV['VAR_BREW_PATH'].to_s == ''
+      env_value = config['VAR_BREW_PATH']&.to_s&.strip || ''
 
-      ENV['VAR_BREW_PATH']
+      return if env_value == ''
+      return unless File.exist?(env_value)
+
+      env_value
     end
 
     def brew_path_from_which
@@ -188,6 +224,8 @@ module Brew
       return if detect == ''
 
       detect
+    rescue Xbar::CommandError
+      nil
     end
 
     def brew_path_from_fs_check
@@ -202,7 +240,7 @@ module Brew
       printer ||= default_printer
       return if File.exist?(brew_path)
 
-      printer.item("#{prefix}↑:warning:", dropdown: false)
+      printer.item("#{prefix}↑⚠️", dropdown: false)
       printer.sep
       printer.item('Homebrew not found', color: 'red')
       printer.item("Executable \"#{brew_path}\" does not exist.")
@@ -213,13 +251,6 @@ module Brew
       )
 
       exit 0
-    end
-
-    def brew_update
-      cmd(brew_path, 'update')
-    rescue CommandError
-      # Continue as if nothing happened when brew update fails, as it likely
-      # to be due to another update process is already running.
     end
   end
 
@@ -253,49 +284,72 @@ module Brew
   end
 
   class FormulaUpdates < Common
-    prefix ':beers:'
+    prefix '🍻'
 
     def run
-      printer = default_printer
-
       brew_check(printer)
       brew_update
 
       printer.item("#{prefix}↑#{formulas.size + casks.size}", dropdown: false)
       printer.sep
-      printer.item('Brew Updates')
+      printer.item('Brew Updates️') do |printer|
+        print_settings(printer)
+      end
 
       printer.item(status_label) do |printer|
-        printer.item(':hourglass: Refresh', refresh: true)
-        printer.sep
-        if formulas.size.positive? && casks.size.positive?
-          printer.item(
-            "Upgrade All (#{formulas.size + casks.size})",
-            terminal: true, refresh: true,
-            shell: [brew_path, 'upgrade'] +
-            formulas.map(&:name) + casks.map(&:name)
-          )
-        end
-        if formulas.size.positive?
-          printer.item(
-            "Upgrade All Formulas (#{formulas.size})",
-            terminal: true, refresh: true,
-            shell: [brew_path, 'upgrade', '--formula'] + formulas.map(&:name)
-          )
-        end
-        if casks.size.positive?
-          printer.item(
-            "Upgrade All Casks (#{casks.size})",
-            terminal: true, refresh: true,
-            shell: [brew_path, 'upgrade', '--cask'] + casks.map(&:name)
-          )
-        end
+        printer.item('⏳ Refresh', alt: '⏳ Refresh (⌘R)', refresh: true)
 
         printer.sep
-        if use_greedy?
-          printer.item('Disable greedy', rpc: ['disable_greedy'], refresh: true)
-        else
-          printer.item('Enable greedy', rpc: ['enable_greedy'], refresh: true)
+        all_formulas = formulas.reject { |f| upgrade_all_exclude?(f.name) }
+        all_casks = casks.reject { |c| upgrade_all_exclude?(c.name) }
+        excluded = (formulas - all_formulas) + (casks - all_casks)
+
+        if all_formulas.size.positive? && all_casks.size.positive?
+          cmds = []
+          if all_formulas.size.positive?
+            cmds += [brew_path, 'upgrade', '--formula'] +
+                    all_formulas.map(&:name)
+          end
+
+          if all_casks.size.positive?
+            cmds << '&&' if cmds.size.positive?
+            cmds += [brew_path, 'upgrade', '--cask'] +
+                    all_casks.map(&:name)
+          end
+
+          printer.item(
+            "⬆️ Upgrade All (#{all_formulas.size + all_casks.size})",
+            terminal: true, refresh: true,
+            shell: (cmds + post_commands).flatten
+          )
+        end
+        if all_formulas.size.positive?
+          names = all_formulas.map(&:name)
+          printer.item(
+            "⬆️ Upgrade All Formulas (#{all_formulas.size})",
+            terminal: true, refresh: true,
+            shell: [
+              brew_path, 'upgrade', '--formula'
+            ] + names + post_commands
+          )
+        end
+        if all_casks.size.positive?
+          names = all_casks.map(&:name)
+          printer.item(
+            "⬆️ Upgrade All Casks (#{all_casks.size})",
+            terminal: true, refresh: true,
+            shell: [
+              brew_path, 'upgrade', '--cask'
+            ] + names + post_commands
+          )
+        end
+        if excluded.size.positive?
+          printer.sep
+          printer.item("Excluded (#{excluded.size}):")
+          excluded.sort_by(&:brew_name).each do |item|
+            type = item.is_a?(Formula) ? 'Formula' : 'Cask'
+            printer.item("#{item.name} (#{type})")
+          end
         end
       end
 
@@ -305,24 +359,77 @@ module Brew
       printer.sep
     end
 
-    def enable_greedy
-      config['VAR_GREEDY'] = true
+    def greedy_latest(*args)
+      config['VAR_GREEDY_LATEST'] = truthy?(args.first)
       config.save
     end
 
-    def disable_greedy
-      config['VAR_GREEDY'] = false
+    def greedy_auto_updates(*args)
+      config['VAR_GREEDY_AUTO_UPDATES'] = truthy?(args.first)
+      config.save
+    end
+
+    def post_run_cleanup(*args)
+      config['VAR_POST_RUN_CLEANUP'] = truthy?(args.first)
+      config.save
+    end
+
+    def post_run_doctor(*args)
+      config['VAR_POST_RUN_DOCTOR'] = truthy?(args.first)
+      config.save
+    end
+
+    def exclude_upgrade_all(*args)
+      exclude = upgrade_all_exclude.clone
+      exclude += args.map(&:strip).reject(&:empty?)
+
+      config['VAR_UPGRADE_ALL_EXCLUDE'] = exclude.sort.join(',')
+      config.save
+    end
+
+    def include_upgrade_all(*args)
+      exclude = upgrade_all_exclude.clone
+      exclude -= args.map(&:strip).reject(&:empty?)
+
+      config['VAR_UPGRADE_ALL_EXCLUDE'] = exclude.sort.join(',')
       config.save
     end
 
     private
 
-    def config
-      @config ||= Xbar::Config.new
+    def greedy_latest?
+      @greedy_latest ||= truthy?(config['VAR_GREEDY_LATEST'])
     end
 
-    def use_greedy?
-      [true, 'true'].include?(config.fetch('VAR_GREEDY', 'false'))
+    def greedy_auto_updates?
+      @greedy_auto_updates ||= truthy?(config['VAR_GREEDY_AUTO_UPDATES'])
+    end
+
+    def post_run_cleanup?
+      @post_run_cleanup ||= truthy?(config['VAR_POST_RUN_CLEANUP'])
+    end
+
+    def post_run_doctor?
+      @post_run_doctor ||= truthy?(config['VAR_POST_RUN_DOCTOR'])
+    end
+
+    def upgrade_all_exclude?(name)
+      upgrade_all_exclude.include?(name)
+    end
+
+    def upgrade_all_exclude
+      @upgrade_all_exclude ||= config.as_set('VAR_UPGRADE_ALL_EXCLUDE')
+    end
+
+    def truthy?(value)
+      %w[true yes 1 on y t].include?(value.to_s.downcase)
+    end
+
+    def brew_update
+      cmd(brew_path, 'update')
+    rescue Xbar::CommandError
+      # Continue as if nothing happened when brew update fails, as it likely
+      # to be due to another update process is already running.
     end
 
     def status_label
@@ -335,36 +442,89 @@ module Brew
       label.join(', ')
     end
 
+    def print_settings(printer)
+      printer.item('Settings')
+      printer.sep
+
+      print_rpc_toggle(
+        printer, 'Greedy: Latest', 'greedy_latest', greedy_latest?
+      )
+
+      print_rpc_toggle(
+        printer, 'Greedy: Auto Updates', 'greedy_auto_updates',
+        greedy_auto_updates?
+      )
+
+      print_rpc_toggle(
+        printer, 'Post Run: Cleanup', 'post_run_cleanup', post_run_cleanup?
+      )
+
+      print_rpc_toggle(
+        printer, 'Post-Run: Doctor', 'post_run_doctor', post_run_doctor?
+      )
+    end
+
+    def print_rpc_toggle(printer, name, rpc, current_value)
+      if current_value
+        icon = '✅'
+        value = 'false'
+      else
+        icon = '☑️'
+        value = 'true'
+      end
+
+      printer.item("#{icon} #{name}", rpc: [rpc, value], refresh: true)
+    end
+
     def print_formulas(printer)
       return unless formulas.size.positive?
 
       printer.sep
       printer.item("Formulas (#{formulas.size}):")
       formulas.each do |formula|
-        printer.item(formula.name) do |printer|
+        name = formula.name
+        name += ' ⤫' if upgrade_all_exclude?(name)
+        printer.item(name) do |printer|
           printer.item(
-            'Upgrade',
-            alt: 'Upgrade ' \
+            '⬆️ Upgrade',
+            alt: '⬆️ Upgrade ' \
                  "(#{formula.current_version} → #{formula.latest_version})",
             terminal: true, refresh: true,
-            shell: [brew_path, 'upgrade', formula.name]
+            shell: [
+              brew_path, 'upgrade', '--formula', formula.name
+            ] + post_commands
           )
           printer.sep
-          printer.item("Installed: #{formula.installed_versions.join(', ')}")
-          printer.item("Latest: #{formula.latest_version}")
+          printer.item("→ Installed: #{formula.installed_versions.join(', ')}")
+          printer.item("↑ Latest: #{formula.latest_version}")
           printer.sep
           printer.item(
-            'Pin',
+            '📌 Pin',
             alt: "Pin (to #{formula.current_version})",
             terminal: false, refresh: true,
             shell: [brew_path, 'pin', formula.name]
           )
-          printer.item('Uninstall') do |printer|
+          if upgrade_all_exclude?(formula.name)
+            printer.item(
+              '✅ Upgrade All: Exclude',
+              terminal: false, refresh: true,
+              rpc: ['include_upgrade_all', formula.name]
+            )
+          else
+            printer.item(
+              '☑️ Upgrade All: Exclude ',
+              terminal: false, refresh: true,
+              rpc: ['exclude_upgrade_all', formula.name]
+            )
+          end
+          printer.item('🚫 Uninstall') do |printer|
             printer.item('Are you sure?')
             printer.item(
               'Yes',
               terminal: true, refresh: true,
-              shell: [brew_path, 'uninstall', formula.name]
+              shell: [
+                brew_path, 'uninstall', '--formula', formula.name
+              ] + post_commands
             )
           end
         end
@@ -377,25 +537,44 @@ module Brew
       printer.sep
       printer.item("Casks (#{casks.size}):")
       casks.each do |cask|
-        printer.item(cask.name) do |printer|
+        name = cask.name
+        name += ' ⤫' if upgrade_all_exclude?(name)
+        printer.item(name) do |printer|
           printer.item(
-            'Upgrade',
-            alt: 'Upgrade '\
+            '⬆️ Upgrade',
+            alt: '⬆️ Upgrade '\
                  "(#{cask.current_version} → #{cask.latest_version})",
             terminal: true, refresh: true,
-            shell: [brew_path, 'upgrade', '--cask', cask.name]
+            shell: [
+              brew_path, 'upgrade', '--cask', cask.name
+            ] + post_commands
           )
           printer.sep
-          printer.item("Installed: #{cask.installed_version}")
-          printer.item("Latest: #{cask.latest_version}")
+          printer.item("→ Installed: #{cask.installed_version}")
+          printer.item("↑ Latest: #{cask.latest_version}")
           printer.sep
-          printer.item('Uninstall') do |printer|
+          if upgrade_all_exclude?(cask.name)
+            printer.item(
+              '✅ Upgrade All: Exclude',
+              terminal: false, refresh: true,
+              rpc: ['include_upgrade_all', cask.name]
+            )
+          else
+            printer.item(
+              '☑️ Upgrade All: Exclude',
+              terminal: false, refresh: true,
+              rpc: ['exclude_upgrade_all', cask.name]
+            )
+          end
+          printer.item('🚫 Uninstall') do |printer|
             printer.item('Are you sure?')
             printer.sep
             printer.item(
               'Yes',
               terminal: true, refresh: true,
-              shell: [brew_path, 'uninstall', '--cask', cask.name]
+              shell: [
+                brew_path, 'uninstall', '--cask', cask.name
+              ] + post_commands
             )
           end
         end
@@ -410,32 +589,42 @@ module Brew
       pinned.each do |formula|
         printer.item(formula.name) do |printer|
           printer.item(
-            'Upgrade',
-            alt: 'Upgrade ' \
+            '⬆ Upgrade',
+            alt: '⬆ Upgrade ' \
                  "(#{formula.current_version} → #{formula.latest_version})"
           )
           printer.sep
-          printer.item("Pinned: #{formula.pinned_version}")
+          printer.item("→ Pinned: #{formula.pinned_version}")
           if formula.installed_versions.size > 1
-            printer.item("Installed: #{formula.installed_versions.join(', ')}")
+            printer.item("→ Installed: #{formula.installed_versions.join(', ')}")
           end
-          printer.item("Latest: #{formula.latest_version}")
+          printer.item("↑ Latest: #{formula.latest_version}")
           printer.sep
           printer.item(
-            'Unpin',
+            '📌 Unpin',
             terminal: false, refresh: true,
             shell: [brew_path, 'unpin', formula.name]
           )
-          printer.item('Uninstall') do |printer|
+          printer.item('🚫 Uninstall') do |printer|
             printer.item('Are you sure?')
             printer.item(
               'Yes',
               terminal: true, refresh: true,
-              shell: [brew_path, 'uninstall', formula.name]
+              shell: [
+                brew_path, 'uninstall', '--formula', formula.name
+              ] + post_commands
             )
           end
         end
       end
+    end
+
+    def post_commands
+      cmds = []
+      cmds += ['&&', brew_path, 'cleanup'] if post_run_cleanup?
+      cmds += ['&&', brew_path, 'doctor'] if post_run_doctor?
+
+      cmds
     end
 
     def formulas
@@ -454,12 +643,15 @@ module Brew
       @casks ||= outdated['casks'].map { |line| Cask.new(line) }
     end
 
+    def greedy_args
+      args = []
+      args << '--greedy-latest' if greedy_latest?
+      args << '--greedy-auto-updates' if greedy_auto_updates?
+      args
+    end
+
     def outdated_args
-      [
-        'outdated',
-        (use_greedy? ? '--greedy' : nil),
-        '--json=v2'
-      ].compact
+      ['outdated', greedy_args, '--json=v2'].flatten.compact
     end
 
     def outdated
@@ -469,11 +661,19 @@ module Brew
 end
 
 begin
-  updates = Brew::FormulaUpdates.new
-  Xbar::Runner.new(updates).run(ARGV)
+  service = Brew::FormulaUpdates.new
+  Xbar::Runner.new(service).run(ARGV)
 rescue StandardError => e
-  puts "ERROR: #{e.message}:\n\t#{e.backtrace.join("\n\t")}"
-  exit 1
+  puts ":warning: #{File.basename(__FILE__)}"
+  puts '---'
+  puts 'exit status 1'
+  puts '---'
+  puts 'Error:'
+  puts e.message.to_s
+  e.backtrace.each do |line|
+    puts "--#{line}"
+  end
+  exit 0
 end
 
 # rubocop:enable Style/IfUnlessModifier


### PR DESCRIPTION
- Add more granular greedy options (latest and auto-updates).
- Add post-run options for optionally running "brew cleanup" and/or
  "brew doctor" after operations that modify packages.
- Add new "Upgrade All: Exclude" option which simply excludes a
  formula/cask when using any of the Upgrade All operations.
- Re-style menus a bit with emoji as icons for most operations.

---

This pulls in the latest changes to the brew-updates plugin from my [dotfiles](https://github.com/jimeh/dotfiles/tree/main/xbar).

**Before:**

![before](https://i.imgur.com/HLKYqYc.png)

**After:**

![after](https://i.imgur.com/HbSHhaa.png)

![settings](https://user-images.githubusercontent.com/39563/226496804-0ce8a0a6-ae14-4a07-beb0-4b2f5f9267a2.png)
