### PR TITLE
March issue fix bundle

### DIFF
--- a/Dev/Gitlab/gitlab_merge_requests.1m.js
+++ b/Dev/Gitlab/gitlab_merge_requests.1m.js
@@ -150,9 +150,7 @@ function request(path) {
           })
           .on("end", () => {
             if (responseBufs.length > 0) {
-              responseStr = Buffer.concat(responseBufs).toString(
-                responseEncoding
-              );
+              responseStr = Buffer.concat(responseBufs).toString(responseEncoding);
             }
 
             resolve(JSON.parse(responseStr));
@@ -215,24 +213,20 @@ async function getMRs() {
     excludedEvents = todaysExcludedEvents;
   }
 
-  const [
-    todaysEvents,
-    createdMRs,
-    assignedMRs,
-    approvalMRs,
-  ] = await Promise.all([
-    request(
-      `/api/v4/users/4557473/events?after=${yesterdayParam}&action=pushed`
-    ),
-    request("/api/v4/merge_requests?scope=created_by_me&state=opened"),
-    request("/api/v4/merge_requests?scope=assigned_to_me&state=opened"),
-    request(
-      `/api/v4/merge_requests?scope=all&state=opened&approver_ids[]=${userId}`
-    ),
-    request(
-      `/api/v4/merge_requests?scope=all&state=opened&reviewer_id[]=${userId}`
-    ),
-  ]);
+  const [todaysEvents, createdMRs, assignedMRs, approvalMRs] =
+      await Promise.all([
+        request(
+            `/api/v4/users/${userId}/events?after=${yesterdayParam}&action=pushed`
+        ),
+        request("/api/v4/merge_requests?scope=created_by_me&state=opened"),
+        request("/api/v4/merge_requests?scope=assigned_to_me&state=opened"),
+        request(
+            `/api/v4/merge_requests?scope=all&state=opened&approver_ids[]=${userId}`
+        ),
+        request(
+            `/api/v4/merge_requests?scope=all&state=opened&reviewer_id[]=${userId}`
+        ),
+      ]);
 
   const allMRs = assignedMRs
     .concat(approvalMRs, createdMRs)

--- a/Network/ssh-tunnel.1s.sh
+++ b/Network/ssh-tunnel.1s.sh
@@ -36,7 +36,7 @@ function hosts() {
 
 for h in $(hosts ~/.ssh/config); do
     if pgrep -qf "ssh -fN ${h}"; then
-        echo "(connecting) ${h} | color=indianred bash=/usr/bin/pkill param1='-f' param2='\"ssh -fN ${h}\"' terminal=false"
+        echo "(connecting) ${h} | color=indianred bash=/usr/bin/pkill param1='-f' param2='ssh -fN ${h}' terminal=false"
     else
         echo "${h} | bash=/usr/bin/ssh param1='-fN' param2=${h} terminal=false"
     fi

--- a/System/Battery/keyboard.1m.sh
+++ b/System/Battery/keyboard.1m.sh
@@ -1,10 +1,14 @@
-#!/bin/sh
+#!/bin/bash
 
 # <xbar.title>Keybard Battery</xbar.title>
 # <xbar.author>Mat Ryer</xbar.author>
 # <xbar.author.github>matryer</xbar.author.github>
 
 PERCENTAGE=$(ioreg -c AppleBluetoothHIDKeyboard | grep BatteryPercent | fgrep -v \{ | sed 's/[^[:digit:]]//g')
+# Detect and adjust for M1 Mac
+if [[ $(uname -m) == 'arm64' ]]; then
+  PERCENTAGE=$(ioreg -c AppleDeviceManagementHIDEventService -r -l | grep -i keyboard -A 20  | grep BatteryPercent | cut -d = -f2 | cut -d ' ' -f2)
+fi
 
 if [ "$PERCENTAGE" ]; then
         echo "Keyboard: $PERCENTAGE%"

--- a/System/Battery/mouse.1m.sh
+++ b/System/Battery/mouse.1m.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # <xbar.title>Mouse battery</xbar.title>
 # <xbar.version>1.0</xbar.version>
 # <xbar.author>Alexandre Espinosa Menor</xbar.author>
@@ -9,6 +9,10 @@
 # works fine with Magic Mouse
 
 PERCENTAGE=$(ioreg -n BNBMouseDevice | fgrep BatteryPercent | fgrep -v \{ | sed 's/[^[:digit:]]//g')
+# Detect and adjust for M1 Mac
+if [[ $(uname -m) == 'arm64' ]]; then
+  PERCENTAGE=$(ioreg -c AppleDeviceManagementHIDEventService -r -l | grep -i mouse -A 20  | grep BatteryPercent | cut -d = -f2 | cut -d ' ' -f2)
+fi
 
 if [ "$PERCENTAGE" ]; then
         echo "Mouse: $PERCENTAGE%"

--- a/System/cpu-usage-kill.5s.sh
+++ b/System/cpu-usage-kill.5s.sh
@@ -13,7 +13,7 @@ counter=1
 ps c -Ao pcpu,command,pid -r | head -n 4 | awk 'NR>1'\
   | while read -r pcpu command pid ; do
 
-    if [ "${counter}" -eq "1" ]; then 
+    if [ "${counter}" -eq "1" ]; then
       echo "$pcpu% $command"
       echo "---"
     fi
@@ -26,4 +26,4 @@ done
 
 
 echo "---"
-echo "Refresh | refresh=true terminal=false root=true"
+echo "Refresh | refresh=true terminal=false"

--- a/System/lock-screen.10h.sh
+++ b/System/lock-screen.10h.sh
@@ -9,13 +9,20 @@
 # <xbar.dependencies></xbar.dependencies>
 
 if [ "$1" = 'lock' ]; then
-  # To perform a sleep action
-  # Requires "password after sleep or screen saver begins" to be set in Security preferences
-  #osascript -e 'tell application "Finder" to sleep'
+  OSVER=$(sw_vers -productVersion | awk -F. '{print $1}')
+  if [[ "$OSVER" -ge 13 ]]; then
+    # The first time you run this will prompt to grant xbar access in the Accessibility features settings.
+    osascript -e 'tell app "System Events" to key code 12 using {control down, command down}'
+  else
+    # To perform a sleep action
+    # Requires "password after sleep or screen saver begins" to be set in Security preferences
+    #osascript -e 'tell application "Finder" to sleep'
 
-  # To perform a lock (login screen) action
-  # Requires "Fast User Switching" to be enabled in system Login preferences
-  /System/Library/CoreServices/Menu\ Extras/User.menu/Contents/Resources/CGSession -suspend
+    # To perform a lock (login screen) action
+    # Requires "Fast User Switching" to be enabled in system Login preferences
+    /System/Library/CoreServices/Menu\ Extras/User.menu/Contents/Resources/CGSession -suspend
+  fi
+
   exit
 fi
 

--- a/Web/YouTube/YouTubeTicker.1m.js
+++ b/Web/YouTube/YouTubeTicker.1m.js
@@ -38,7 +38,7 @@ renderPlugin();
 
 function renderPlugin(){
   if(key == "<YOUR-KEY-HERE>"){
-    console.log("CLICK ME TO CONFIGURE YOUTUBE TICKER |color:red image="+youTubeIcon );
+    console.log("CLICK ME TO CONFIGURE YOUTUBE TICKER |color=red image="+youTubeIcon );
     console.log("---");
     console.log("Please watch the following setup video. [Click to visit site] |href="+setupVideoLink);
     console.log("---");


### PR DESCRIPTION
 - `cpu-usage-kill.5s.sh`: Remove deprecated `root=true` parameter. Closes #1846, Closes #1742
 - `ssh-tunnel.1s.sh`: Remove escaped double quotes in command. Closes #1893
 - `lock-screen.10h.sh`: Alter script to detect OS version and adjust command for Big Sur and later. Closes #1751
 - `dnscrypt-proxy-switcher.10s.sh`: Update from upstream repository. Closes #1520
 - `YouTubeTicker.1m.js`: Fix color parameter issue.
 - `gitlab_merge_requests.js`: Rename file to include timing. Fix hardcoded user ID issue. Closes #1695