### PR TITLE
Python fixes for March 2023

### DIFF
--- a/Cryptocurrency/binance-ticker.6s.py
+++ b/Cryptocurrency/binance-ticker.6s.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S PATH="${PATH}:/opt/homebrew/bin:/usr/local/bin" python3
 
 # <xbar.title>Binance Price Ticker</xbar.title>
 # <xbar.version>v1.1</xbar.version>
@@ -19,7 +19,7 @@ coin_symbols=['BNBBTC', 'ETHBTC']
 #https://api.binance.com/api/v1/ticker/24hr
 
 for coin_symbol in coin_symbols:
-    url="https://api.binance.com/api/v1/ticker/24hr?symbol={}".format(coin_symbol)
+    url="https://data.binance.com/api/v3/ticker/24hr?symbol={}".format(coin_symbol)
     payload=urlopen(url)
 
     data = json.load(payload)

--- a/Environment/conda-envs.15m.py
+++ b/Environment/conda-envs.15m.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # <xbar.title>Anaconda Environments</xbar.title>
@@ -106,7 +106,7 @@ def get_conda_envs():
     out = subp.check_output(cmd, stderr=subp.STDOUT).strip()
     envs = []
     for env in out.splitlines():
-        if not env.strip().startswith('#'):
+        if not env.strip().startswith(b'#'):
             tuple = env.split()
             name = tuple[0]
             path = tuple[1]

--- a/Finance/transferwise-currency-tracker.1m.py
+++ b/Finance/transferwise-currency-tracker.1m.py
@@ -7,15 +7,21 @@
 # <xbar.desc>Keep an eye on Transferwise currency exchange rates</xbar.desc>
 # <xbar.dependencies>python</xbar.dependencies>
 # <xbar.image>http://andrewzk.github.io/gh-pages/transferwise.png</xbar.image>
+# <xbar.var>string(VAR_CURRENCY_FROM="USD"): The currency you are converting from.</xbar.var>
+# <xbar.var>string(VAR_CURRENCY_TO="DKK"): The currency you are converting to.</xbar.var>
+# <xbar.var>string(VAR_CURRENCY_FROM_LABEL="🇺🇸USD"): The currency you are converting from.</xbar.var>
+# <xbar.var>string(VAR_CURRENCY_TO_LABEL="🇩🇰DKK"): The currency you are converting to.</xbar.var>
 
 import urllib.request, urllib.error, urllib.parse
 import json
+import os
+
+currency_from = os.environ.get("VAR_CURRENCY_FROM")
+currency_to = os.environ.get("VAR_CURRENCY_TO")
+currency_from_label = os.environ.get("VAR_CURRENCY_FROM_LABEL")
+currency_to_label = os.environ.get("VAR_CURRENCY_TO_LABEL")
 
 TRANSFERWISE_KEY = "dad99d7d8e52c2c8aaf9fda788d8acdc"
-
-# Replace with desired currencies
-currency_from = 'USD'
-currency_to = 'DKK'
 
 url = "https://transferwise.com/api/v1/payment/calculate?amount=1" \
       "&amountCurrency=source&hasDiscount=false&isFixedRate=false" \
@@ -27,6 +33,6 @@ req.add_header('X-Authorization-key', TRANSFERWISE_KEY)
 
 result = json.loads(urllib.request.urlopen(req).read())['transferwiseRate']
 
-print("{}: {:.2f}".format(currency_to, result))
+print("{}: {:.2f}".format(currency_to_label, result))
 print("---")
-print("From: {}".format(currency_from))
+print("From: {}".format(currency_from_label))

--- a/Finance/yahoo_stock_ticker.10m.py
+++ b/Finance/yahoo_stock_ticker.10m.py
@@ -20,7 +20,7 @@ import subprocess
 
 # ---------------------------------------------------------------------------------------------------------------------
 # Enter your stock symbols here in the format: ["symbol1", "symbol2", ...]
-symbols = ["FB", "AAPL", "AMZN", "NFLX", "GOOG", "BIDU", "BABA", "TCEHY"]
+symbols = ["AAPL", "AMZN", "NFLX", "GOOG", "BIDU", "BABA", "TCEHY"]
 
 # Enter the order how you want to sort the stock list:
 # 'name'                     : Sort alphabetically by name from A to Z

--- a/Lifestyle/taskwarrior.4m.py
+++ b/Lifestyle/taskwarrior.4m.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env -S PATH="${PATH}:/opt/homebrew/bin:/usr/local/bin" python3
 # -*- coding: utf-8 -*-
 #
 # Taskwarrior
@@ -30,7 +30,8 @@ from subprocess import Popen, PIPE
 def trigger_actions(argv):
     t_id = argv[-1]
     action = argv[-2]
-    subprocess.call(['/usr/local/bin/task', t_id, action])
+    path_task = subprocess.check_output(['which', 'task']).decode('ascii').rstrip()
+    subprocess.call([path_task, t_id, action])
 
 
 def build_command(t_id, action, refresh=True):
@@ -39,7 +40,7 @@ def build_command(t_id, action, refresh=True):
     if refresh:
         cmd = cmd + ' refresh=true'
 
-    cmd = cmd + ' bash=/usr/bin/python param1=' + __file__ + ' param2='
+    cmd = cmd + ' bash=python3 param1=' + __file__ + ' param2='
 
     cmd = cmd + action
 
@@ -63,8 +64,10 @@ def print_output(
         alternate_command=''):
     output = ''
 
+    path_task = subprocess.check_output(['which', 'task']).decode('ascii').rstrip()
+
     # important: PIPE the stderr, since task likes to use that - a lot ...
-    p = Popen(['/usr/local/bin/task', cmd],
+    p = Popen([path_task, cmd],
               stdin=None, stdout=PIPE, stderr=PIPE)
     output, err = p.communicate()
 

--- a/Time/countdown.1s.py
+++ b/Time/countdown.1s.py
@@ -7,9 +7,14 @@
 # <xbar.desc>Shows countdown of established date.</xbar.desc>
 # <xbar.image>https://cloud.githubusercontent.com/assets/7404532/12356787/ae62636c-bba4-11e5-8ff8-6a1eaffcbfc2.png</xbar.image>
 # <xbar.dependencies>python</xbar.dependencies>
+# <xbar.var>string(VAR_TITLE="Countdown Timer"): Title to display in menu bar</xbar.var>
+# <xbar.var>string(VAR_DATE_FORMAT="%d-%m-%Y"): The date / time format for the timers you are setting up</xbar.var>
+# <xbar.var>boolean(VAR_NO_CYCLE=false): If true, times will not cycle in the menu bar but will be displayed in the drop-down menu</xbar.var>
+# <xbar.var>string(VAR_TIMERS="Time #1:17-07-2073,Time #2:15-08-2073"): Comma delimited list of timers you wish to set. Each list entry is a colon separated label and date / time matching the format set in the DATE_FORMAT variable.</xbar.var>
 
 from datetime import datetime
 import sys
+import os
 
 
 def dateDiffInSeconds(date1, date2):
@@ -25,72 +30,28 @@ def daysHoursMinutesSecondsFromSeconds(seconds):
 
 
 def main():
+    bar_title = os.environ.get("VAR_TITLE")
+    date_format = os.environ.get("VAR_DATE_FORMAT")
+    no_cycle = os.environ.get("VAR_NO_CYCLE")
+    timers = os.environ.get("VAR_TIMERS").split(",")
 
-    if "--help" in sys.argv:
-        print(
-            """
-To pass arguments to this script, you can create a separate sh file and execute the main script with it.
-
-Available Args:
-    --bar-title: This will appear as the first line in the output. The default is 'Countdown Timer'.
-    --date-format: You can provide a custom date format. The default is '%d-%m-%Y %H:%M'
-    --no-cycle: If this is present in the arguments, the times will not cycle.
-    --help: Prints this message and exits.
-
-Example:
-    countdown.py "--bar-title" "Custom Bar Title" "--no-cycle" "--date-format" "%d-%m-%Y" "Time #1" "17-07-2017" "Time #2" "15-08-2017"
-Script Example:
-    chmod +x /Path/to/countdown.py && /Path/to/countdown.py "--bar-title" "Custom Bar Title" "--no-cycle" "--date-format" "%d-%m-%Y" "Time #1" "17-07-2017" "Time #2" "15-08-2017"
-            """
-        )
-        return
-
-    arg_count = len(sys.argv)
     now = datetime.now()
-    date_format = '%d-%m-%Y %H:%M'
-    bar_title = "Countdown Timer"
-
-    label = ""
     time = None
 
-    if "--bar-title" in sys.argv:
-        found_index = sys.argv.index("--bar-title")
-        if len(sys.argv) > found_index + 1:
-            bar_title = sys.argv[found_index + 1]
-
-    if "--date-format" in sys.argv:
-        found_index = sys.argv.index("--date-format")
-        if len(sys.argv) > found_index + 1:
-            date_format = sys.argv[found_index + 1]
-
-    print(bar_title + " | font=\'Monospace\'")
-    if "--no-cycle" in sys.argv:
+    if no_cycle == "false":
+        print(bar_title + " | font=\'Monospace\'")
         print("---")
 
-    if arg_count == 1:
-        print("""
-            Please pass the correct arguments for this plugin to work.
-            You can create an sh file that executes the main Python
-            script file with the appropriate arguments.
-            For examples, see the script file.
-        """)
-
-    for index in range(1, arg_count):
-        arg = sys.argv[index].strip()
-        if arg == "--no-cycle":
-            continue
-
-        if arg == "--bar-title":
-            continue
-
-        if index > 0 and sys.argv[index - 1] == "--date-format":
-            continue
+    for timer in timers:
+        timerData = timer.split(":")
+        label = timerData[0]
+        timer_date = timerData[1]
 
         try:
-            time = datetime.strptime(arg, date_format)
+            time = datetime.strptime(timer_date, date_format)
             print(label + ": %d d, %d h, %d m | font=\'Monospace\'" % daysHoursMinutesSecondsFromSeconds(dateDiffInSeconds(now, time)))
-        except ValueError:
-            label = arg
+        except ValueError as e:
+            print(e)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 - `taskwarrior.4m.py`: Use python3 and add PATH spec including M1 Homebrew location. Closes #1912, #1044
 - `binance-ticker.6s.py`: Update API URL. Closes #1529
 - `yahoo_stock_ticker.10m.py`: Remove invalid stock symbol
 - `transferwise-currency-tracker.1m.py`: Move configuration into xbar variables. Add label variables. Closes #1242
 - `conda-envs.15m.py`: Update to python3 and fix encoding error. Closes #830
 - `countdown.1s.py`: Complete overhaul to use xbar variables instead of script wrapper. Closes #951