### PR TITLE
Issue #1753 - Fix bluetooth inspector error

### DIFF
--- a/System/bluetooth_inspector.10m.rb
+++ b/System/bluetooth_inspector.10m.rb
@@ -550,14 +550,14 @@ module BluetoothInspector
     def parse(data)
       data = YAML.load(data.to_s)
 
-      data["Bluetooth"]["Devices (Paired, Configured, etc.)"].collect do |name, attributes|
+      data["Bluetooth"]["Connected"].collect do |name, attributes|
         Device.new(
           name:       name,
           battery:    attributes["Battery Level"],
           major_type: attributes["Major Type"],
           minor_type: attributes["Minor Type"],
           paired:     attributes["Paired"],
-          connected:  attributes["Connected"],
+          connected:  true,
         )
       end
     end


### PR DESCRIPTION
- Changes to system profiler since plugin creation returns the Bluetooth data in a different format. This updates how the data is pulled.