### PR TITLE
fix(productivitycountdowns): remove leading zeros in month_number

### DIFF
--- a/Time/productivitycountdowns.1h.sh
+++ b/Time/productivitycountdowns.1h.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # <xbar.title>Productivity Countdowns</xbar.title>
-# <xbar.version>v1.1</xbar.version>
+# <xbar.version>v1.1.1</xbar.version>
 # <xbar.author>Jacopo Lorenzetti</xbar.author>
 # <xbar.author.github>jlorenzetti</xbar.author.github>
 # <xbar.desc>This plugin will show the current ISO week number and a few productivity boosting countdowns.</xbar.desc>
@@ -15,7 +15,7 @@ unix_time=$(date +%s)
 day_of_year=$(date +%j)
 day_of_week=$(date +%w)
 week_number=$(date +%V)
-month_number=$(date +%m)
+month_number=$((10#$(date +%m)))
 quarter=$(((month_number - 1) / 3 + 1))
 
 function format_countdown {


### PR DESCRIPTION
This commit fixes the issue where the script would fail when the month number had a leading zero. Numbers with leading zeros are treated as octal in Bash, causing arithmetic errors when the month is 08 or 09.

By using arithmetic expansion, the leading zeros are removed, ensuring that the month_number variable is treated as a base-10 integer.