### PR TITLE
[crypto/eth/gasnow] Change source of gas price beaconcha.in instead etherchain.org

### DIFF
--- a/Cryptocurrency/Ethereum/gasnow.10s.sh
+++ b/Cryptocurrency/Ethereum/gasnow.10s.sh
@@ -10,7 +10,7 @@
 #
 #ETH GasPrice forecast system based on SparkPool Pending Transaction Mempool
 
-response=$(curl -s https://etherchain.org/api/gasnow)
+response=$(curl -s https://beaconcha.in/api/v1/execution/gasnow)
 read code rapid fast standard slow timestamp <<<${response//[^0-9]/ }
 echo "𝚵 Rapid ${rapid:0:((${#rapid} - 9))} | color=green" 
 echo "𝚵 Fast ${fast:0:((${#fast} - 9))} | color=orange"


### PR DESCRIPTION
Proof of correctness
```bash
% curl -s https://etherchain.org/api/gasnow


<a href="https://beaconcha.in/api/v1/execution/gasnow">See Other</a>.
```

```bash
% curl -s https://beaconcha.in/api/v1/execution/gasnow


{"code":200,"data":{"rapid":31264073768,"fast":22823173145,"standard":15005140596,"slow":12000000000,"timestamp":1704749499243,"price":2345.6206,"priceUSD":2345.6206}}
```