### PR TITLE
cpu-load.5s.sh: remove Bash dependency

### DIFF
--- a/System/cpu-load.5s.sh
+++ b/System/cpu-load.5s.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # <xbar.title>CPU Load</xbar.title>
-# <xbar.version>v1.0</xbar.version>
+# <xbar.version>v1.1</xbar.version>
 # <xbar.author>Paul W. Rankin</xbar.author>
 # <xbar.author.github>rnkn</xbar.author.github>
 # <xbar.desc>Shows CPU load as a percentage (without using top).</xbar.desc>

--- a/System/cpu-load.5s.sh
+++ b/System/cpu-load.5s.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # <xbar.title>CPU Load</xbar.title>
 # <xbar.version>v1.0</xbar.version>
@@ -6,7 +6,6 @@
 # <xbar.author.github>rnkn</xbar.author.github>
 # <xbar.desc>Shows CPU load as a percentage (without using top).</xbar.desc>
 # <xbar.image>https://i.imgur.com/B6VAsDg.png</xbar.image>
-# <xbar.dependencies>bash</xbar.dependencies>
 
 # BitBar CPU Load plugin
 


### PR DESCRIPTION
macOS Bash is very old (3.2)