### PR TITLE
Fix timestamp calculation in Nightscout xbar plugin

### DIFF
--- a/Lifestyle/nightscout.1m.sh
+++ b/Lifestyle/nightscout.1m.sh
@@ -27,15 +27,17 @@ else
     JSONOUT=$(curl --silent "${VAR_NSURL}/api/v1/entries/current.json")
 fi
 
-JSDATE=$(jq '.[0].date' <<< "$JSONOUT")
-#NS Returns date as ms since epoch. BASH likes Seconds since epoch
-EPOCHTS=$((JSDATE / 1000))
+JSDATE=$(jq -r '.[0].date' <<< "$JSONOUT")
+
+# Convert the timestamp to a full integer using awk (handles decimals)
+EPOCH_RAW=$(awk -v ts="$JSDATE" 'BEGIN { printf "%.0f", ts }')
+EPOCHTS=$((EPOCH_RAW / 1000))
 TIMESTRING=$(date -r $EPOCHTS)
 
 EPOCHNOW=$(date +%s) # Convert current time to epoch time
 TIMEDIFF=$(((EPOCHNOW - EPOCHTS)/60)) #calculate the difference
 
-BG=$(jq '.[0].sgv' <<< "$JSONOUT")
+BG=$(jq -r '.[0].sgv' <<< "$JSONOUT")
 
 TRENDSTR=$(jq -r '.[0].direction' <<< "$JSONOUT")
 


### PR DESCRIPTION
This PR addresses an issue where the Nightscout xbar plugin displays incorrect time differences (e.g. "28988905m ago").

**Changes Made:**
- Added proper decimal handling for the timestamp conversion using `awk`
- Added `-r` flag to `jq` commands to ensure raw string output
- Ensures accurate time difference display (e.g. "2m ago" instead of large incorrect values)

**Testing:**
1. Install the updated plugin
2. Verify that the time difference shown is reasonable (e.g. "2m ago", "5m ago")
3. Monitor over time to ensure values remain accurate

Fixes #2089 

---
Note: This change maintains all existing functionality while fixing the timestamp display issue. No changes to the plugin's configuration or dependencies are required.