### PR TITLE
multichain compatibile with etherscan V2 endpoint

### DIFF
--- a/Cryptocurrency/multichain_gas_widget.5s.rb
+++ b/Cryptocurrency/multichain_gas_widget.5s.rb
@@ -4,7 +4,7 @@
 # <bitbar.version>v1.0</bitbar.version>
 # <bitbar.author>Masumi Kawasaki</bitbar.author>
 # <bitbar.author.github>geeknees</bitbar.author.github>
-# <bitbar.desc>Widget for monitoring Ethereum Gas Fees from https://etherscan.io/</bitbar.desc>
+# <bitbar.desc>Widget for monitoring Gas Fees from https://etherscan.io/</bitbar.desc>
 # <bitbar.dependencies>ruby</bitbar.dependencies>
 # <bitbar.image>https://raw.githubusercontent.com/geeknees/xbar-plugins/main/eth_gas_widget/screenshot.png</bitbar.image>
 # <bitbar.abouturl>https://github.com/geeknees/xbar-plugins</bitbar.abouturl>
@@ -12,8 +12,9 @@
 require 'open-uri'
 require 'json'
 
-ENDPOINT = "https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey="
-APIKEY = ""
+CHAINID = 1 # Ethereum mainnet. See other available chains at https://api.etherscan.io/v2/chainlist and endpoints at https://forms.blockscan.com/public/grid/3E9QiN00NLhCQVibiP3Z-Bpqhmd7zGXsgapEKJupxiI
+ENDPOINT = "ENDPOINT = https://api.etherscan.io/v2/api?chainid=#{CHAINID}&module=gastracker&action=gasoracle&apikey="
+APIKEY = "" # ETHERSCAN API KEY
 
 charset = nil
 html = URI.open(ENDPOINT+APIKEY) do |f|
@@ -23,9 +24,9 @@ end
 
 response = JSON.parse(html)
 
-puts "⟠ #{response['result']['ProposeGasPrice']}"
+puts "⟠ #{response['result']['ProposeGasPrice'].to_f.floor(6)}"
 puts '---'
 
 response['result'].each do |k, v|
-  puts "#{k}: #{v.to_f.floor(5)}"
+  puts "#{k}: #{v.to_f.floor(6)}"
 end


### PR DESCRIPTION
- Updated @geeknees's Ethereum gas widget to use the [new V2 endpoints](https://info.etherscan.com/etherscan-api-v2-multichain/).
- Added multichain compatibility by allowing users to input a chain ID of their choice (provided that the chain is supported by etherscan)